### PR TITLE
fix: menaces dropdownmenu

### DIFF
--- a/frontend/app/zh-advanced-search/components/evaluations/zh-advanced-search-evaluations.component.html
+++ b/frontend/app/zh-advanced-search/components/evaluations/zh-advanced-search-evaluations.component.html
@@ -36,7 +36,7 @@
       <div class="form-group col-6">
         <zh-label label="Menaces potentielles ou avérées"> </zh-label>
       </div>
-      <div class="form-group col-6 customselect">
+      <div class="form-group col-6 customselect menaces">
         <angular2-multiselect
           [data]="menaces"
           [formControl]="form.controls.menaces"

--- a/frontend/app/zh-advanced-search/components/evaluations/zh-advanced-search-evaluations.component.scss
+++ b/frontend/app/zh-advanced-search/components/evaluations/zh-advanced-search-evaluations.component.scss
@@ -3,3 +3,7 @@
 .customselect {
   max-width: 300px;
 }
+
+.menaces {
+  padding-bottom: 250px;
+}

--- a/frontend/app/zh-advanced-search/components/evaluations/zh-advanced-search-evaluations.component.ts
+++ b/frontend/app/zh-advanced-search/components/evaluations/zh-advanced-search-evaluations.component.ts
@@ -23,7 +23,8 @@ export class ZhAdvancedSearchEvaluationsComponent implements OnInit {
       primaryKey: "id_nomenclature",
       searchPlaceholderText: "Rechercher",
       enableSearchFilter: true,
-      autoPosition: true,
+      autoPosition: false,
+      position: "bottom"
     };
   }
 


### PR DESCRIPTION
Sur certaines instances, le menu déroulant des menaces dans les filtres pas visible quand il est déployé vers le bas