### PR TITLE
fix(db): order of declare permissions migration

### DIFF
--- a/backend/gn_module_zh/migrations/510677623a13_declare_permisision.py
+++ b/backend/gn_module_zh/migrations/510677623a13_declare_permisision.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "510677623a13"
-down_revision = "22b14fc3abe0"
+down_revision = "643743e807f6"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
La migration https://github.com/PnX-SI/gn_module_ZH/blob/dev/backend/gn_module_zh/migrations/510677623a13_declare_permisision.py n'était pas dans le bon ordre et avait la même `down_revision` que https://github.com/PnX-SI/gn_module_ZH/blob/dev/backend/gn_module_zh/migrations/22b14fc3abe0_set_srid.py

Cette PR remet la `down_revision` à la dernière migration : https://github.com/PnX-SI/gn_module_ZH/blob/dev/backend/gn_module_zh/migrations/643743e807f6_add_atlas_view.py