### PR TITLE
fix: error rb name null in complete card

### DIFF
--- a/frontend/app/zh-details/hierarchy/hierarchy.component.html
+++ b/frontend/app/zh-details/hierarchy/hierarchy.component.html
@@ -1,4 +1,4 @@
-<h4 class="tabsSubtitle">Bassin versant : {{ data.river_basin_name }}</h4>
+<h4 class="tabsSubtitle">Bassin versant : {{ data?.river_basin_name }}</h4>
 <zh-table
   [tableCols]="hierarchy.hierTableCols"
   [data]="hierarchy.items"


### PR DESCRIPTION
fix error when opening a complete card where river basin name is null