### PR TITLE
feat: make zh-search-input multiplable + update river basin and knowledge behacvior

### DIFF
--- a/backend/gn_module_zh/search.py
+++ b/backend/gn_module_zh/search.py
@@ -193,16 +193,16 @@ def filter_hydro(query, json):
     return query
 
 
-def filter_basin(query, json):
-    codes = [area.get("code", None) for area in json]
+def filter_basin(query, basin):
+    code = basin.get("code", None)
 
-    if codes is not None:
+    if code is not None:
         subquery = (
             select(
                 TRiverBasin.id_rb,
                 TRiverBasin.geom,
             )
-            .where(TRiverBasin.id_rb.in_(codes))
+            .where(TRiverBasin.id_rb == code)
             .subquery()
         )
         # SET_SRID does not return a valid geom...

--- a/frontend/app/zh-hierarchy-search/components/zh-hierarchy-search-table.component.html
+++ b/frontend/app/zh-hierarchy-search/components/zh-hierarchy-search-table.component.html
@@ -4,7 +4,7 @@
       <span class="mr-1">OU</span>
       <mat-slide-toggle
         [formControl]="form.controls.and"
-        matTooltip="Si OU est choisi, les zones humides recherchées respecteront au moins 1 critère listé ci-dessous. 
+        matTooltip="Si OU est choisi, les zones humides recherchées respecteront au moins 1 critère listé ci-dessous.
         Si ET est choisi: elles respecteront tous les critères"
       >
       </mat-slide-toggle>
@@ -39,7 +39,7 @@
     </div>
     <div class="pr-0 col-lg-3 col-6">
       <h5>Attribut</h5>
-      <zh-multiselect 
+      <zh-multiselect
         [values]="attributes"
         [parentFormControl]="localForm.controls.attributes"
         keyLabel="attribut"
@@ -49,11 +49,12 @@
     </div>
     <div class="pr-0 col-lg-3 col-6">
       <h5>Connaissance</h5>
-      <zh-multiselect 
+      <zh-multiselect
         [values]="knowledges"
         [parentFormControl]="localForm.controls.knowledges"
         keyLabel="note_type"
         (onChange)="attributesChanged($event)"
+        [multiple]="false"
       />
     </div>
     <div class="pr-0 col-lg-2 col-6">

--- a/frontend/app/zh-search/zh-search-items/components/zh-search-input/zh-search-input.component.html
+++ b/frontend/app/zh-search/zh-search-items/components/zh-search-input/zh-search-input.component.html
@@ -3,10 +3,10 @@
     <zh-label [label]="label"> </zh-label>
   </div>
   <div class="form-group col-md-7 customselect">
-    <zh-multiselect 
+    <zh-multiselect
       [values]="data"
       [parentFormControl]="form"
-      [multiple]="false"
+      [multiple]="multiple"
       keyLabel="name"
       (change)="onSelected.emit($event)"
     />

--- a/frontend/app/zh-search/zh-search-items/components/zh-search-input/zh-search-input.component.ts
+++ b/frontend/app/zh-search/zh-search-items/components/zh-search-input/zh-search-input.component.ts
@@ -11,6 +11,7 @@ export class ZhSearchInputComponent implements OnInit {
   @Input() label: string = '';
   @Input() displayCode: boolean = false;
   @Input() form: FormGroup;
+  @Input() multiple: boolean = false;
   @Output() onSelected = new EventEmitter<object>();
 
   public dropdownSettings = {

--- a/frontend/app/zh-search/zh-search.component.html
+++ b/frontend/app/zh-search/zh-search.component.html
@@ -14,6 +14,7 @@
         [form]="_searchService.searchForm.get('basin')"
         [data]="basins"
         (onSelected)="onBasinSelected($event)"
+        [multiple]="false"
       >
       </zh-search-input>
       <zh-search-dependant


### PR DESCRIPTION
# ZH-search-component

L'objectif est de permettre que le composant zh-search-component permettent la multiselection.

Il a été appliqué ici au champs bassin versant de la section filtre.

![image](https://github.com/user-attachments/assets/6dd89c5a-8283-47b8-b04e-bea7b500e562)
