### PR TITLE
fix(lint): prettier behavior

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,26 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - name: Cache npm
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ./frontend
+
+      - name: Display Prettier version
+        run: npx prettier --version
+        working-directory: ./frontend
+
+      - name: Display contents
+        run: cat .prettierrc .prettierignore
+        working-directory: ./frontend
+
       - name: Frontend code formatting check (Prettier)
-        run: npm install prettier && npm run format:check
+        run: npm run format:check
         working-directory: ./frontend

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,1 @@
+node_modules

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "format": "prettier --config .prettierrc --ignore-path .prettierignore --write '**/*.ts' ",
-    "format:check": "prettier --config .prettierrc --ignore-path .prettierignore '**/*.ts' "
+    "format": "prettier --config .prettierrc --ignore-path .prettierignore --write '**/*.{ts,html,scss}' ",
+    "format:check": "prettier --config .prettierrc --ignore-path .prettierignore --check '**/*.{ts,html,scss}' "
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
fix(wip) prettier linter

- [x] add --check argument 
- [x] add "node_modules" to .prettierignore
- [x] use same prettier version of app in package.json
- [x] add html and scss prettier linter 
- [x] ajout d'une github action pour sauvegarder en cache l'installation des packages npm (npm install est ré éxécuter uniquement si le package-lock.json à été modifié) --> améliore le temps d'éxécution des github action 

Reviewed-by: andriacap