### PR TITLE
fix: hierarchy subcategories names

### DIFF
--- a/backend/gn_module_zh/hierarchy.py
+++ b/backend/gn_module_zh/hierarchy.py
@@ -859,14 +859,14 @@ class Item:
         try:
             return (
                 DB.session.execute(
-                    select(TRules, BibHierCategories)
+                    select(TRules, BibHierSubcategories)
                     .join(TRules)
                     .where(TRules.rule_id == self.rule_id)
                 )
                 .all()[0]
-                .BibHierCategories.label.capitalize()
+                .BibHierSubcategories.label.capitalize()
             )
-        except NoResultFound:
+        except:
             pass
         return (
             DB.session.execute(


### PR DESCRIPTION
fix hierachy subcategory name errors in tab 9 (since sqlalchemy updates) : 

error : 
![image](https://github.com/user-attachments/assets/9972e6ec-1796-4343-80e0-465bb14b5f7e)

after fix : 
![image](https://github.com/user-attachments/assets/0a1815c4-80b3-4342-861b-3e010d52a069)
