### PR TITLE
Fix/hierarchy filter no rb

### DIFF
--- a/backend/gn_module_zh/hierarchy.py
+++ b/backend/gn_module_zh/hierarchy.py
@@ -859,14 +859,14 @@ class Item:
         try:
             return (
                 DB.session.execute(
-                    select(TRules, BibHierCategories)
+                    select(TRules, BibHierSubcategories)
                     .join(TRules)
                     .where(TRules.rule_id == self.rule_id)
                 )
                 .all()[0]
-                .BibHierCategories.label.capitalize()
+                .BibHierSubcategories.label.capitalize()
             )
-        except NoResultFound:
+        except:
             pass
         return (
             DB.session.execute(

--- a/backend/gn_module_zh/search.py
+++ b/backend/gn_module_zh/search.py
@@ -105,7 +105,7 @@ def main_search(query, json):
     # --- Hierarchy search
     hierarchy = json.get("hierarchy")
     if hierarchy is not None and basin is not None:
-        query = filter_hierarchy(query, json=hierarchy, basin=basin[0].get("name"))
+        query = filter_hierarchy(query, json=hierarchy, basin=basin["name"])
 
     return query
 

--- a/frontend/app/zh-hierarchy-search/components/zh-hierarchy-search-table.component.html
+++ b/frontend/app/zh-hierarchy-search/components/zh-hierarchy-search-table.component.html
@@ -60,7 +60,7 @@
         [parentFormControl]="localForm.controls.attributes"
         keyLabel="attribut"
         (onChange)="attributesChanged($event)"
-        [multiple]="knowledges.length"
+        [multiple]="attributes.length"
       />
     </div>
     <div class="pr-0 col-lg-3 col-6">

--- a/frontend/app/zh-hierarchy-search/components/zh-hierarchy-search-table.component.html
+++ b/frontend/app/zh-hierarchy-search/components/zh-hierarchy-search-table.component.html
@@ -60,7 +60,6 @@
         [parentFormControl]="localForm.controls.attributes"
         keyLabel="attribut"
         (onChange)="attributesChanged($event)"
-        [multiple]="attributes.length"
       />
     </div>
     <div class="pr-0 col-lg-3 col-6">

--- a/frontend/app/zh-hierarchy-search/components/zh-hierarchy-search-table.component.html
+++ b/frontend/app/zh-hierarchy-search/components/zh-hierarchy-search-table.component.html
@@ -28,6 +28,7 @@
           <option
             class="option-title"
             [value]="field.name"
+            disabled
           >
             {{ field.name | uppercase }}
           </option>
@@ -36,6 +37,7 @@
             <option
               *ngIf="cat?.name"
               [value]="cat.name"
+              [disabled]="cat.subcategory.length !== 1"
             >
               <span>&nbsp;{{ cat.name | capitalize }}</span>
             </option>

--- a/frontend/app/zh-hierarchy-search/components/zh-hierarchy-search-table.component.ts
+++ b/frontend/app/zh-hierarchy-search/components/zh-hierarchy-search-table.component.ts
@@ -7,7 +7,7 @@ import { HierarchyField, HierarchyFields, Note, RiverBasin } from '../../models/
 import { TableColumn } from '../../commonComponents/table/table-interface';
 
 type Data = {
-  kownledges: string[];
+  knowledges: string[];
   field: string;
   attributes: string;
 };
@@ -62,7 +62,7 @@ export class ZhHierarchySearchTableComponent implements OnInit {
     private _zhService: ZhDataService,
     private _toastr: ToastrService,
     private _error: ErrorTranslatorService
-  ) {}
+  ) { }
 
   get data() {
     return this.form.controls['hierarchy'] as FormArray;
@@ -87,7 +87,7 @@ export class ZhHierarchySearchTableComponent implements OnInit {
           this.fields = [];
           this.notes = [];
         })
-        .finally(() => {});
+        .finally(() => { });
     }
   }
 
@@ -119,7 +119,7 @@ export class ZhHierarchySearchTableComponent implements OnInit {
         (item.rubrique == event && item.sousrubrique == null) ||
         item.sousrubrique == event
     );
-
+    
     // Creates kind of a Set to have unique objects
     this.attributes = filteredNotes.filter(
       (v, i, a) => a.findIndex((v2) => ['attribut'].every((k) => v2[k] === v[k])) === i
@@ -130,12 +130,12 @@ export class ZhHierarchySearchTableComponent implements OnInit {
     if (this.attributes.length > 0) {
       this.knowledges = this.getKnowledge(this.attributes[0]);
     }
-
+    
     if (this.attributes.length > 0) {
-      this.localForm.controls['attributes'].setValue([this.attributes[0]]);
+      this.localForm.controls["attributes"].setValue([this.attributes[0]]);
     }
     if (this.knowledges.length > 0) {
-      this.localForm.controls['knowledges'].setValue([this.knowledges[0]]);
+      this.localForm.controls["knowledges"].setValue([this.knowledges]);
     }
   }
 
@@ -170,10 +170,18 @@ export class ZhHierarchySearchTableComponent implements OnInit {
       const form = this.initialForm();
       form.patchValue(this.localForm.value);
       this.data.push(form);
-      // Reset all form data
-      this.reset();
-    }
-  }
+      let knowledges_array = []
+      this.data.value.forEach(element => {
+        if ((element['knowledges'] !== null) && (!(Array.isArray(element['knowledges'])))) {
+          // avoid object object in 'connaissance' column of the frontend table
+          knowledges_array.push(element['knowledges']);
+          element['knowledges'] = knowledges_array;
+          knowledges_array = []
+        }
+      })
+    }  
+    this.reset();
+  };
 
   onDeleteFilter(event) {
     const item = this.getFilterIndex(event);

--- a/frontend/app/zh-hierarchy-search/components/zh-hierarchy-search-table.component.ts
+++ b/frontend/app/zh-hierarchy-search/components/zh-hierarchy-search-table.component.ts
@@ -144,17 +144,14 @@ export class ZhHierarchySearchTableComponent implements OnInit {
     if (this.attributes.length) {
       attributesControl.enable();
       attributesControl.setValue([this.attributes[0]]);
-    }
-    else {
+    } else {
       attributesControl.disable();
     }
-
 
     if (this.knowledges.length > 0) {
       knowledgeControl.enable();
       knowledgeControl.setValue(this.knowledges[0]);
-    }
-    else {
+    } else {
       knowledgeControl.disable();
     }
   }

--- a/frontend/app/zh-hierarchy-search/components/zh-hierarchy-search-table.component.ts
+++ b/frontend/app/zh-hierarchy-search/components/zh-hierarchy-search-table.component.ts
@@ -87,7 +87,9 @@ export class ZhHierarchySearchTableComponent implements OnInit {
           this.fields = [];
           this.notes = [];
         })
-        .finally(() => {});
+        .finally(() => {
+          this.updateAttributesAndKnowledgeForm();
+        });
     }
   }
 
@@ -110,9 +112,6 @@ export class ZhHierarchySearchTableComponent implements OnInit {
   }
 
   fieldChanged(event) {
-    this.localForm.controls['attributes'].reset();
-    this.localForm.controls['knowledges'].reset();
-
     const filteredNotes = this.notes.filter(
       (item) =>
         (item.volet == event && item.rubrique == null && item.sousrubrique == null) ||
@@ -131,11 +130,32 @@ export class ZhHierarchySearchTableComponent implements OnInit {
       this.knowledges = this.getKnowledge(this.attributes[0]);
     }
 
-    if (this.attributes.length > 0) {
-      this.localForm.controls['attributes'].setValue([this.attributes[0]]);
+    // Update the form
+    this.updateAttributesAndKnowledgeForm();
+  }
+
+  updateAttributesAndKnowledgeForm() {
+    const knowledgeControl = this.localForm.controls['knowledges'];
+    const attributesControl = this.localForm.controls['attributes'];
+
+    attributesControl.reset();
+    knowledgeControl.reset();
+
+    if (this.attributes.length) {
+      attributesControl.enable();
+      attributesControl.setValue([this.attributes[0]]);
     }
+    else {
+      attributesControl.disable();
+    }
+
+
     if (this.knowledges.length > 0) {
-      this.localForm.controls['knowledges'].setValue([this.knowledges]);
+      knowledgeControl.enable();
+      knowledgeControl.setValue(this.knowledges[0]);
+    }
+    else {
+      knowledgeControl.disable();
     }
   }
 

--- a/frontend/app/zh-hierarchy-search/components/zh-hierarchy-search-table.component.ts
+++ b/frontend/app/zh-hierarchy-search/components/zh-hierarchy-search-table.component.ts
@@ -62,7 +62,7 @@ export class ZhHierarchySearchTableComponent implements OnInit {
     private _zhService: ZhDataService,
     private _toastr: ToastrService,
     private _error: ErrorTranslatorService
-  ) { }
+  ) {}
 
   get data() {
     return this.form.controls['hierarchy'] as FormArray;
@@ -87,7 +87,7 @@ export class ZhHierarchySearchTableComponent implements OnInit {
           this.fields = [];
           this.notes = [];
         })
-        .finally(() => { });
+        .finally(() => {});
     }
   }
 
@@ -119,7 +119,7 @@ export class ZhHierarchySearchTableComponent implements OnInit {
         (item.rubrique == event && item.sousrubrique == null) ||
         item.sousrubrique == event
     );
-    
+
     // Creates kind of a Set to have unique objects
     this.attributes = filteredNotes.filter(
       (v, i, a) => a.findIndex((v2) => ['attribut'].every((k) => v2[k] === v[k])) === i
@@ -130,12 +130,12 @@ export class ZhHierarchySearchTableComponent implements OnInit {
     if (this.attributes.length > 0) {
       this.knowledges = this.getKnowledge(this.attributes[0]);
     }
-    
+
     if (this.attributes.length > 0) {
-      this.localForm.controls["attributes"].setValue([this.attributes[0]]);
+      this.localForm.controls['attributes'].setValue([this.attributes[0]]);
     }
     if (this.knowledges.length > 0) {
-      this.localForm.controls["knowledges"].setValue([this.knowledges]);
+      this.localForm.controls['knowledges'].setValue([this.knowledges]);
     }
   }
 
@@ -170,18 +170,18 @@ export class ZhHierarchySearchTableComponent implements OnInit {
       const form = this.initialForm();
       form.patchValue(this.localForm.value);
       this.data.push(form);
-      let knowledges_array = []
-      this.data.value.forEach(element => {
-        if ((element['knowledges'] !== null) && (!(Array.isArray(element['knowledges'])))) {
+      let knowledges_array = [];
+      this.data.value.forEach((element) => {
+        if (element['knowledges'] !== null && !Array.isArray(element['knowledges'])) {
           // avoid object object in 'connaissance' column of the frontend table
           knowledges_array.push(element['knowledges']);
           element['knowledges'] = knowledges_array;
-          knowledges_array = []
+          knowledges_array = [];
         }
-      })
-    }  
+      });
+    }
     this.reset();
-  };
+  }
 
   onDeleteFilter(event) {
     const item = this.getFilterIndex(event);

--- a/frontend/app/zh-hierarchy-search/zh-hierarchy-search.component.html
+++ b/frontend/app/zh-hierarchy-search/zh-hierarchy-search.component.html
@@ -8,12 +8,12 @@
     <div class="card-body">
       <div
         class="row"
-        *ngIf="riverBasin?.value?.length > 0; else noZone"
+        *ngIf="riverBasin?.value?.code !== undefined; else noZone"
       >
         <div class="col-12">
           <zh-hierarchy-search-table
             [form]="form"
-            [riverBasin]="riverBasin?.value[0]"
+            [riverBasin]="riverBasin?.value"
           ></zh-hierarchy-search-table>
         </div>
       </div>

--- a/frontend/app/zh-hierarchy-search/zh-hierarchy-search.component.html
+++ b/frontend/app/zh-hierarchy-search/zh-hierarchy-search.component.html
@@ -8,7 +8,7 @@
     <div class="card-body">
       <div
         class="row"
-        *ngIf="riverBasin?.value?.code !== undefined; else noZone"
+        *ngIf="riverBasin?.value?.code; else noZone"
       >
         <div class="col-12">
           <zh-hierarchy-search-table

--- a/frontend/app/zh-search/zh-search.component.ts
+++ b/frontend/app/zh-search/zh-search.component.ts
@@ -95,6 +95,8 @@ export class ZhSearchComponent implements OnInit {
   onReset() {
     this._searchService.reset();
     // Emit empty object to search all ZH
+    this.hierarchySearchToggled = false;
+    this.advancedSearchToggled = false;
     this.onSearch.emit();
   }
 


### PR DESCRIPTION
corrections d'une série de bugs sur les filtres de hiérarchisation : 
- veuillez indiquer le bassin versant alors que bassin versant déjà sélectionné : 
![image](https://github.com/user-attachments/assets/e84bc038-3045-406e-bb16-4d76f1a5bc78)
- des object object dans la colonne 'connaissance' des filtres lorsqu'on rajoute des éléments à la recherche par hierarchisation suivant 
- des incohérences ou comportements inattendus dans les colonnes 'attributs' ou 'connaissance' selon la sélection de l'élément (s'ils s'agit d'une sous-rubrique ayant des valeurs de connaissance existant ou rubrique sans valeur de connaissance existantes)

![image](https://github.com/user-attachments/assets/d4ce62ed-1a2a-483a-ad8a-95dfa0cea704)

- correction du reset des incomplets des filtres : disable le toggle des filtres avancés et des filtres de hiérarchisation : pouvait amener des confusions et erreurs parce que lorsqu'on cliquait sur 'réinitialiser', le bassin versant était supprimé dans les filtres mais la recherche pas hiérarchisation n'était pas disable

![image](https://github.com/user-attachments/assets/c3c8bcbe-eb34-4207-a8e8-a778ea3f03ac)
