### PR TITLE
Replace Hydro Area error, Object instead of Hydro Area name

### DIFF
--- a/backend/gn_module_zh/model/cards.py
+++ b/backend/gn_module_zh/model/cards.py
@@ -509,9 +509,10 @@ class Basin:
     def __get_hydro_zones(self):
         return [
             name
-            for name in DB.session.execute(
-                select(THydroArea.name)
-                .where(THydroArea.id_hydro == CorZhHydro.id_hydro, CorZhHydro.id_zh == self.id_zh)
+            for (name,) in DB.session.execute(
+                select(THydroArea.name).where(
+                    THydroArea.id_hydro == CorZhHydro.id_hydro, CorZhHydro.id_zh == self.id_zh
+                    )
                 .distinct()
             ).all()
         ]


### PR DESCRIPTION
Les zones hydrographiques n'apparaissaient pas sur notre instance.
![image](https://github.com/user-attachments/assets/8ea5b7ef-01f3-4daf-99da-3b491cdbea92)


Modifier la fonction `__get_hydro_zones` dans le fichier [cards.py](https://github.com/PnX-SI/gn_module_ZH/blob/3ffb8d1d5119c8345e0e2fce1b487666627f1b27/backend/gn_module_zh/model/cards.py#L509) permet de remettre les bonnes valeurs dans la fiche : 

![image](https://github.com/user-attachments/assets/9ccd8c3b-d9dd-4035-8517-93f51522949a)


https://github.com/PnX-SI/gn_module_ZH/blob/3ffb8d1d5119c8345e0e2fce1b487666627f1b27/backend/gn_module_zh/model/cards.py#L509-L517

