### PR TITLE
fix river basin names and improve errors in hierarchy

### DIFF
--- a/backend/gn_module_zh/blueprint.py
+++ b/backend/gn_module_zh/blueprint.py
@@ -614,7 +614,7 @@ def get_tab_data(id_tab):
                 form_data["update_date"],
                 geom["polygon"],
                 area,
-                active_geo_refs
+                active_geo_refs,
             )
             intersection = geom["is_intersected"]
         else:
@@ -629,7 +629,7 @@ def get_tab_data(id_tab):
                 area,
                 g.current_user,
                 form_data["update_date"],
-                active_geo_refs
+                active_geo_refs,
             )
             intersection = geom["is_intersected"]
 

--- a/backend/gn_module_zh/forms.py
+++ b/backend/gn_module_zh/forms.py
@@ -67,7 +67,9 @@ def create_zh(form_data, info_role, zh_date, polygon, zh_area, ref_geo_referenti
     code = str(uuid.uuid4())[0:12]
 
     # main river basin
-    rbs = TZH.get_zh_area_intersected("river_basin", func.ST_GeomFromGeoJSON(str(form_data["geom"]["geometry"])))
+    rbs = TZH.get_zh_area_intersected(
+        "river_basin", func.ST_GeomFromGeoJSON(str(form_data["geom"]["geometry"]))
+    )
     main_id_rb = get_main_rb(rbs, form_data["geom"]["geometry"])
 
     # create zh : fill pr_zh.t_zh
@@ -83,7 +85,7 @@ def create_zh(form_data, info_role, zh_date, polygon, zh_area, ref_geo_referenti
         id_sdage=form_data["sdage"],
         geom=polygon,
         area=zh_area,
-        main_id_rb=main_id_rb
+        main_id_rb=main_id_rb,
     )
     DB.session.add(new_zh)
     DB.session.flush()
@@ -261,7 +263,9 @@ def update_zh_tab0(form_data, polygon, area, info_role, zh_date, geo_refs):
     main_id_rb = DB.session.get(TZH, form_data["id_zh"]).main_id_rb
 
     if is_geom_new:
-        rbs = TZH.get_zh_area_intersected("river_basin", func.ST_GeomFromGeoJSON(str(form_data["geom"]["geometry"])))
+        rbs = TZH.get_zh_area_intersected(
+            "river_basin", func.ST_GeomFromGeoJSON(str(form_data["geom"]["geometry"]))
+        )
         main_id_rb = get_main_rb(rbs, form_data["geom"]["geometry"])
         update_cor_zh_area(polygon, form_data["id_zh"], geo_refs)
         update_cor_zh_rb(form_data["geom"]["geometry"], form_data["id_zh"], rbs)
@@ -281,7 +285,7 @@ def update_zh_tab0(form_data, polygon, area, info_role, zh_date, geo_refs):
             geom=polygon,
             area=area,
             ef_area=ef_area,
-            main_id_rb=main_id_rb
+            main_id_rb=main_id_rb,
         )
     )
 

--- a/backend/gn_module_zh/forms.py
+++ b/backend/gn_module_zh/forms.py
@@ -44,6 +44,7 @@ from .model.zh_schema import (
     TOwnership,
     TUrbanPlanningDocs,
 )
+from .geometry import get_main_rb
 
 
 def update_tzh(data):
@@ -65,6 +66,10 @@ def create_zh(form_data, info_role, zh_date, polygon, zh_area, ref_geo_referenti
     # temporary code
     code = str(uuid.uuid4())[0:12]
 
+    # main river basin
+    rbs = TZH.get_zh_area_intersected("river_basin", func.ST_GeomFromGeoJSON(str(form_data["geom"]["geometry"])))
+    main_id_rb = get_main_rb(rbs, form_data["geom"]["geometry"])
+
     # create zh : fill pr_zh.t_zh
     new_zh = TZH(
         main_name=form_data["main_name"],
@@ -78,6 +83,7 @@ def create_zh(form_data, info_role, zh_date, polygon, zh_area, ref_geo_referenti
         id_sdage=form_data["sdage"],
         geom=polygon,
         area=zh_area,
+        main_id_rb=main_id_rb
     )
     DB.session.add(new_zh)
     DB.session.flush()
@@ -111,7 +117,7 @@ def create_zh(form_data, info_role, zh_date, polygon, zh_area, ref_geo_referenti
         )
 
     # fill cor_zh_rb
-    post_cor_zh_rb(form_data["geom"]["geometry"], new_zh.id_zh)
+    post_cor_zh_rb(form_data["geom"]["geometry"], new_zh.id_zh, rbs)
     # fill cor_zh_hydro
     post_cor_zh_hydro(form_data["geom"]["geometry"], new_zh.id_zh)
     # fill cor_zh_fct_area
@@ -131,22 +137,6 @@ def create_zh(form_data, info_role, zh_date, polygon, zh_area, ref_geo_referenti
 
     DB.session.flush()
     return new_zh.id_zh
-
-
-# except ZHApiError:
-#     raise
-# except Exception as e:
-#     if e.__class__.__name__ == "DataError":
-#         raise ZHApiError(
-#             message="create_zh_post_db_error",
-#             details=str(e.orig.diag.sqlstate + ": " + e.orig.diag.message_primary),
-#             status_code=400,
-#         )
-#     exc_type, value, tb = sys.exc_info()
-#     raise ZHApiError(
-#         message="create_zh_post_error",
-#         details=str(exc_type) + ": " + str(e.with_traceback(tb)),
-#     )
 
 
 def post_cor_lim_list(uuid_lim, criteria):
@@ -204,36 +194,12 @@ def post_cor_zh_area(polygon, id_zh, id_type):
             cover = None
         DB.session.add(CorZhArea(id_area=element, id_zh=id_zh, cover=cover))
         DB.session.flush()
-    # except Exception as e:
-    #     if e.__class__.__name__ == "DataError":
-    #         raise ZHApiError(
-    #             message="post_cor_zh_area_db_error",
-    #             details=str(e.orig.diag.sqlstate + ": " + e.orig.diag.message_primary),
-    #         )
-    #     exc_type, value, tb = sys.exc_info()
-    #     raise ZHApiError(
-    #         message="post_cor_zh_area_error",
-    #         details=str(exc_type) + ": " + str(e.with_traceback(tb)),
-    #     )
 
 
-def post_cor_zh_rb(geom, id_zh):
-    # try:
-    rbs = TZH.get_zh_area_intersected("river_basin", func.ST_GeomFromGeoJSON(str(geom)))
+def post_cor_zh_rb(geom, id_zh, rbs):
     for rb in rbs:
         DB.session.add(CorZhRb(id_zh=id_zh, id_rb=rb.id_rb))
         DB.session.flush()
-    # except Exception as e:
-    #     if e.__class__.__name__ == "DataError":
-    #         raise ZHApiError(
-    #             message="post_cor_zh_rb_db_error",
-    #             details=str(e.orig.diag.sqlstate + ": " + e.orig.diag.message_primary),
-    #         )
-    #     exc_type, value, tb = sys.exc_info()
-    #     raise ZHApiError(
-    #         message="post_cor_zh_rb_error",
-    #         details=str(exc_type) + ": " + str(e.with_traceback(tb)),
-    #     )
 
 
 def post_cor_zh_hydro(geom, id_zh):
@@ -292,10 +258,13 @@ def update_zh_tab0(form_data, polygon, area, info_role, zh_date, geo_refs):
 
     DB.session.execute(delete(CorLimList).where(CorLimList.id_lim_list == id_lim_list))
     post_cor_lim_list(id_lim_list, form_data["critere_delim"])
+    main_id_rb = DB.session.get(TZH, form_data["id_zh"]).main_id_rb
 
     if is_geom_new:
+        rbs = TZH.get_zh_area_intersected("river_basin", func.ST_GeomFromGeoJSON(str(form_data["geom"]["geometry"])))
+        main_id_rb = get_main_rb(rbs, form_data["geom"]["geometry"])
         update_cor_zh_area(polygon, form_data["id_zh"], geo_refs)
-        update_cor_zh_rb(form_data["geom"]["geometry"], form_data["id_zh"])
+        update_cor_zh_rb(form_data["geom"]["geometry"], form_data["id_zh"], rbs)
         update_cor_zh_hydro(form_data["geom"]["geometry"], form_data["id_zh"])
         ef_area = update_cor_zh_fct_area(form_data["geom"]["geometry"], form_data["id_zh"])
 
@@ -312,22 +281,12 @@ def update_zh_tab0(form_data, polygon, area, info_role, zh_date, geo_refs):
             geom=polygon,
             area=area,
             ef_area=ef_area,
+            main_id_rb=main_id_rb
         )
     )
 
     DB.session.flush()
     return form_data["id_zh"]
-    # except Exception as e:
-    #     if e.__class__.__name__ == "DataError":
-    #         raise ZHApiError(
-    #             message="update_tab0_db_error",
-    #             details=str(e.orig.diag.sqlstate + ": " + e.orig.diag.message_primary),
-    #             status_code=400,
-    #         )
-    #     exc_type, value, tb = sys.exc_info()
-    #     raise ZHApiError(
-    #         message="update_tab0_error", details=str(exc_type) + ": " + str(e.with_traceback(tb))
-    #     )
 
 
 def check_polygon(polygon, id_zh):
@@ -389,9 +348,9 @@ def update_cor_zh_area(polygon, id_zh, geo_refs):
         )
 
 
-def update_cor_zh_rb(geom, id_zh):
+def update_cor_zh_rb(geom, id_zh, rbs):
     DB.session.execute(delete(CorZhRb).where(CorZhRb.id_zh == id_zh))
-    post_cor_zh_rb(geom, id_zh)
+    post_cor_zh_rb(geom, id_zh, rbs)
 
 
 def update_cor_zh_hydro(geom, id_zh):

--- a/backend/gn_module_zh/forms.py
+++ b/backend/gn_module_zh/forms.py
@@ -607,7 +607,7 @@ def post_outflow(id_zh, outflows):
 
 def update_inflow(id_zh, inflows):
     try:
-        DB.session.execute(select(TInflow).where(TInflow.id_zh == id_zh))
+        DB.session.execute(delete(TInflow).where(TInflow.id_zh == id_zh))
         post_inflow(id_zh, inflows)
     except Exception as e:
         if e.__class__.__name__ == "DataError":
@@ -823,7 +823,7 @@ def post_instruments(id_zh, instruments):
 
 def update_protections(id_zh, protections):
     try:
-        DB.session.execute(select(CorZhProtection).where(CorZhProtection.id_zh == id_zh))
+        DB.session.execute(delete(CorZhProtection).where(CorZhProtection.id_zh == id_zh))
         post_protections(id_zh, protections)
     except Exception as e:
         if e.__class__.__name__ == "DataError":
@@ -931,7 +931,7 @@ def post_urban_docs(id_zh, urban_docs):
 def update_actions(id_zh, actions):
     try:
         # delete cascade actions
-        DB.session.execute(select(TActions).where(TActions.id_zh == id_zh))
+        DB.session.execute(delete(TActions).where(TActions.id_zh == id_zh))
         # post new actions
         post_actions(id_zh, actions)
     except Exception as e:

--- a/backend/gn_module_zh/geometry.py
+++ b/backend/gn_module_zh/geometry.py
@@ -86,27 +86,15 @@ def set_area(geom):
     )
 
 
-def get_main_rb(query: list) -> int:
+def get_main_rb(rbs, geom):
     rb_id = None
     area = 0
-    for q_ in query:
-        zh_polygon = DB.session.execute(
-            select(TZH.geom).where(TZH.id_zh == getattr(q_, "id_zh"))
-        ).scalar_one()
-
-        rb_polygon = DB.session.execute(
-            select(TRiverBasin.geom)
-            .select_from(CorZhRb)
-            .join(TRiverBasin, TRiverBasin.id_rb == CorZhRb.id_rb)
-            .where(TRiverBasin.id_rb == getattr(q_, "id_rb"))
-            .limit(1)
-        ).scalar_one()
-
+    for q_ in rbs:
         intersection = DB.session.scalar(
             select(
                 func.ST_Intersection(
-                    func.ST_GeomFromText(func.ST_AsText(zh_polygon)),
-                    func.ST_GeomFromText(func.ST_AsText(rb_polygon)),
+                    func.ST_GeomFromText(func.ST_AsText(func.ST_GeomFromGeoJSON(str(geom)))),
+                    func.ST_GeomFromText(func.ST_AsText(getattr(q_, "geom"))),
                 )
             )
         )

--- a/backend/gn_module_zh/hierarchy.py
+++ b/backend/gn_module_zh/hierarchy.py
@@ -1,7 +1,5 @@
 import sys
 from itertools import groupby
-from werkzeug.exceptions import NotFound
-
 
 from geonature.utils.env import DB
 from pypnnomenclature.models import BibNomenclaturesTypes, TNomenclatures
@@ -1134,11 +1132,9 @@ class Volet2(Volet):
 
 
 class Hierarchy(ZH):
-    def __init__(self, id_zh):
+    def __init__(self, id_zh, main_id_rb):
         self.id_zh = id_zh
-        self.rb_id = self.__get_rb()
-        if not self.rb_id:
-            raise NotFound("The ZH is not in a river basin")
+        self.rb_id = main_id_rb
         self.is_rules = self.__check_if_rules()
         self.volet1 = Volet1(self.id_zh, self.rb_id)
         self.volet2 = Volet2(self.id_zh, self.rb_id)
@@ -1161,16 +1157,6 @@ class Hierarchy(ZH):
             )
         else:
             return None
-
-    def __get_rb(self):
-        q_rb = ZH.get_data_by_id(CorZhRb, self.id_zh)
-        if not q_rb:
-            return None
-        if len(q_rb) > 1:
-            return get_main_rb(q_rb)
-        return DB.session.execute(
-            select(CorZhRb.id_rb, TRiverBasin).join(TRiverBasin).where(CorZhRb.id_zh == self.id_zh)
-        ).scalar_one()
 
     def __check_if_rules(self):
         try:

--- a/backend/gn_module_zh/migrations/58ab8aba8512_add_main_id_rb_column.py
+++ b/backend/gn_module_zh/migrations/58ab8aba8512_add_main_id_rb_column.py
@@ -1,0 +1,38 @@
+"""add_main_id_rb_column
+
+Revision ID: 58ab8aba8512
+Revises: 76e89c793961
+Create Date: 2024-09-11 15:14:12.546662
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import Column, Integer
+
+
+# revision identifiers, used by Alembic.
+revision = "58ab8aba8512"
+down_revision = "76e89c793961"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        schema="pr_zh",
+        table_name="t_zh",
+        column=Column(
+            "main_id_rb",
+            Integer,
+            nullable=True,
+        ),
+    )
+
+
+def downgrade():
+    op.drop_column(
+        schema="pr_zh",
+        table_name="t_zh",
+        column_name="main_id_rb",
+    )

--- a/backend/gn_module_zh/migrations/72a8378567pa_update_main_id_rb.py
+++ b/backend/gn_module_zh/migrations/72a8378567pa_update_main_id_rb.py
@@ -1,4 +1,4 @@
-"""add_main_id_rb_column
+"""update_main_id_rb
 
 Revision ID: 72a8378567pa
 Revises: 58ab8aba8512
@@ -20,20 +20,20 @@ depends_on = None
 def upgrade():
     op.execute(
         """
-        UPDATE pr_zh.t_zh tzh 
-        SET main_id_rb = 
+        UPDATE pr_zh.t_zh tzh
+        SET main_id_rb =
         (
-            SELECT id_rb 
+            SELECT id_rb
             FROM (
                 SELECT
-                    czr.id_rb AS id_rb, 
+                    czr.id_rb AS id_rb,
                     ST_Area(ST_Intersection(
                         ST_GeomFromText(ST_AsText((SELECT geom FROM pr_zh.t_zh WHERE id_zh = tzh.id_zh ))),
                         ST_GeomFromText(ST_AsText(trb.geom))
-                    )) AS areas									
+                    )) AS areas
                 FROM pr_zh.cor_zh_rb czr
                 LEFT JOIN pr_zh.t_river_basin trb ON trb.id_rb = czr.id_rb
-                WHERE czr.id_zh = tzh.id_zh 
+                WHERE czr.id_zh = tzh.id_zh
                 ORDER BY areas DESC
                 LIMIT 1
             ) AS a
@@ -45,7 +45,7 @@ def upgrade():
 def downgrade():
     op.execute(
         """
-        UPDATE pr_zh.t_zh tzh 
+        UPDATE pr_zh.t_zh tzh
         SET main_id_rb = null
         """
     )

--- a/backend/gn_module_zh/migrations/72a8378567pa_update_main_id_rb.py
+++ b/backend/gn_module_zh/migrations/72a8378567pa_update_main_id_rb.py
@@ -1,0 +1,51 @@
+"""add_main_id_rb_column
+
+Revision ID: 72a8378567pa
+Revises: 58ab8aba8512
+Create Date: 2024-09-11 17:18:21.165324
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "72a8378567pa"
+down_revision = "58ab8aba8512"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute(
+        """
+        UPDATE pr_zh.t_zh tzh 
+        SET main_id_rb = 
+        (
+            SELECT id_rb 
+            FROM (
+                SELECT
+                    czr.id_rb AS id_rb, 
+                    ST_Area(ST_Intersection(
+                        ST_GeomFromText(ST_AsText((SELECT geom FROM pr_zh.t_zh WHERE id_zh = tzh.id_zh ))),
+                        ST_GeomFromText(ST_AsText(trb.geom))
+                    )) AS areas									
+                FROM pr_zh.cor_zh_rb czr
+                LEFT JOIN pr_zh.t_river_basin trb ON trb.id_rb = czr.id_rb
+                WHERE czr.id_zh = tzh.id_zh 
+                ORDER BY areas DESC
+                LIMIT 1
+            ) AS a
+        )
+        """
+    )
+
+
+def downgrade():
+    op.execute(
+        """
+        UPDATE pr_zh.t_zh tzh 
+        SET main_id_rb = null
+        """
+    )

--- a/backend/gn_module_zh/migrations/data/script_create_tables.sql
+++ b/backend/gn_module_zh/migrations/data/script_create_tables.sql
@@ -279,6 +279,7 @@ CREATE  TABLE pr_zh.t_zh (
 	remark_is_other_inventory  varchar(2000)   ,
 	main_pict_id         integer   ,
 	area				 real	,
+	main_id_rb			 integer	,
 	CONSTRAINT pk_t_zh_zh_id PRIMARY KEY ( id_zh ),
 	CONSTRAINT unq_t_zh_code UNIQUE ( code ) ,
 	CONSTRAINT unq_t_zh UNIQUE ( zh_uuid ) 

--- a/backend/gn_module_zh/model/cards.py
+++ b/backend/gn_module_zh/model/cards.py
@@ -1185,8 +1185,10 @@ class Card(ZH):
 
     def __set_hierarchy(self):
         return {
-            "main_basin_name": DB.session.scalar(select(TRiverBasin.name).where(TRiverBasin.id_rb == self.main_id_rb)),
-            "hierarchy": self.hierarchy.as_dict() if self.hierarchy is not None else None
+            "main_basin_name": DB.session.scalar(
+                select(TRiverBasin.name).where(TRiverBasin.id_rb == self.main_id_rb)
+            ),
+            "hierarchy": self.hierarchy.as_dict() if self.hierarchy is not None else None,
         }
 
     def __set_evaluation(self):

--- a/backend/gn_module_zh/model/cards.py
+++ b/backend/gn_module_zh/model/cards.py
@@ -499,21 +499,21 @@ class Basin:
     def __get_river_basins(self):
         return [
             name
-            for (name,) in DB.session.execute(
+            for name in DB.session.scalars(
                 select(TRiverBasin.name).where(
                     TRiverBasin.id_rb == CorZhRb.id_rb, CorZhRb.id_zh == self.id_zh
                 )
-            ).all()
+            )
         ]
 
     def __get_hydro_zones(self):
         return [
             name
-            for name in DB.session.execute(
+            for name in DB.session.scalars(
                 select(THydroArea.name)
                 .where(THydroArea.id_hydro == CorZhHydro.id_hydro, CorZhHydro.id_zh == self.id_zh)
                 .distinct()
-            ).all()
+            )
         ]
 
 
@@ -1004,8 +1004,9 @@ class Action:
 
 
 class Card(ZH):
-    def __init__(self, id_zh, type, ref_geo_config):
+    def __init__(self, id_zh, main_id_rb, type, ref_geo_config):
         self.id_zh = id_zh
+        self.main_id_rb = main_id_rb
         self.type = type
         self.ref_geo_config = ref_geo_config
         self.properties = self.get_properties()
@@ -1018,7 +1019,7 @@ class Card(ZH):
         self.status = Status()
         self.evaluation = Evaluation()
         try:
-            self.hierarchy = Hierarchy(id_zh)
+            self.hierarchy = Hierarchy(id_zh, main_id_rb)
         except (NotFound, ZHApiError):
             self.hierarchy = None
 
@@ -1183,7 +1184,10 @@ class Card(ZH):
         return self.status.__str__()
 
     def __set_hierarchy(self):
-        return self.hierarchy.as_dict() if self.hierarchy is not None else None
+        return {
+            "main_basin_name": DB.session.scalar(select(TRiverBasin.name).where(TRiverBasin.id_rb == self.main_id_rb)),
+            "hierarchy": self.hierarchy.as_dict() if self.hierarchy is not None else None
+        }
 
     def __set_evaluation(self):
         self.__set_main_functions()

--- a/backend/gn_module_zh/model/zh_schema.py
+++ b/backend/gn_module_zh/model/zh_schema.py
@@ -314,10 +314,13 @@ class TZH(ZhModel):
             ).all()
         ]
         return ", ".join([str(item) for item in bassin_versant])
-    
+
     @hybrid_property
     def main_rb_name(self):
-        return DB.session.scalar(select(TRiverBasin.name).where(TRiverBasin.id_rb == self.main_id_rb))
+        return DB.session.scalar(
+            select(TRiverBasin.name).where(TRiverBasin.id_rb == self.main_id_rb)
+        )
+
 
 @serializable
 class CorZhArea(DB.Model):

--- a/backend/gn_module_zh/model/zh_schema.py
+++ b/backend/gn_module_zh/model/zh_schema.py
@@ -247,6 +247,7 @@ class TZH(ZhModel):
     remark_is_other_inventory = DB.Column(DB.Unicode)
     main_pict_id = DB.Column(DB.Integer)
     area = DB.Column(DB.Float)
+    main_id_rb = DB.Column(DB.Integer, nullable=True)
 
     sdage = DB.relationship(
         TNomenclatures,
@@ -313,7 +314,10 @@ class TZH(ZhModel):
             ).all()
         ]
         return ", ".join([str(item) for item in bassin_versant])
-
+    
+    @hybrid_property
+    def main_rb_name(self):
+        return DB.session.scalar(select(TRiverBasin.name).where(TRiverBasin.id_rb == self.main_id_rb))
 
 @serializable
 class CorZhArea(DB.Model):

--- a/frontend/app/commonComponents/table/table.component.html
+++ b/frontend/app/commonComponents/table/table.component.html
@@ -15,7 +15,7 @@
     <ng-container *ngIf="data && data.length > 0">
       <tr
         [ngStyle]="{
-          background: item[color_col_name] == color_value ? '#EBFFE5' : 'rgba(67, 175, 0, 0.04)'
+          background: item[color_col_name] == color_value ? '#EBFFE5' : 'rgba(67, 175, 0, 0.04)',
         }"
         *ngFor="let item of data"
       >

--- a/frontend/app/commonComponents/table/table.component.html
+++ b/frontend/app/commonComponents/table/table.component.html
@@ -15,7 +15,7 @@
     <ng-container *ngIf="data && data.length > 0">
       <tr
         [ngStyle]="{
-          background: item[color_col_name] == color_value ? '#EBFFE5' : 'rgba(67, 175, 0, 0.04)',
+          background: item[color_col_name] == color_value ? '#EBFFE5' : 'rgba(67, 175, 0, 0.04)'
         }"
         *ngFor="let item of data"
       >

--- a/frontend/app/services/error-translator.service.ts
+++ b/frontend/app/services/error-translator.service.ts
@@ -116,9 +116,7 @@ export class ErrorTranslatorService {
   }
 
   getFrontError(errorMsg: string): string {
-    console.log('error:', errorMsg);
     const frontError: error = this.getError(errorMsg);
-    console.log(frontError);
     return frontError ? frontError.front : 'Erreur inconnue';
   }
 

--- a/frontend/app/services/hierarchy.service.ts
+++ b/frontend/app/services/hierarchy.service.ts
@@ -24,7 +24,6 @@ export class HierarchyService {
   public currentZh: any;
   //public hierZh: HierarchyModel = null;
   public items: ItemModel[];
-  public rb_name: string;
   public isLoading: boolean = false;
 
   constructor(
@@ -38,9 +37,8 @@ export class HierarchyService {
   }
 
   // get current zone humides
-  getHierarchy(zhId, rb_name) {
+  getHierarchy(zhId) {
     this.isLoading = true;
-    this.rb_name = rb_name;
     this._dataService.getHierZh(zhId).subscribe(
       (data: HierarchyModel) => {
         this.items = this.setItems(data);

--- a/frontend/app/services/hierarchy.service.ts
+++ b/frontend/app/services/hierarchy.service.ts
@@ -47,7 +47,7 @@ export class HierarchyService {
       })
       .subscribe(
         (data: HierarchyModel) => {
-          this.items = this.setItems(data);
+          this.setItems(data);
         },
         (error) => {
           this.isLoading = false;
@@ -345,7 +345,5 @@ export class HierarchyService {
       note: data.final_note,
     });
     //this.bold_row_values.push("NOTE FINALE");
-
-    return this.items;
   }
 }

--- a/frontend/app/zh-details/hierarchy/hierarchy.component.html
+++ b/frontend/app/zh-details/hierarchy/hierarchy.component.html
@@ -1,4 +1,4 @@
-<h4 class="tabsSubtitle">Bassin versant : {{ data?.river_basin_name }}</h4>
+<h4 class="tabsSubtitle">Bassin versant : {{ main_river_basin_name }}</h4>
 <zh-table
   [tableCols]="hierarchy.hierTableCols"
   [data]="hierarchy.items"

--- a/frontend/app/zh-details/hierarchy/hierarchy.component.ts
+++ b/frontend/app/zh-details/hierarchy/hierarchy.component.ts
@@ -13,11 +13,11 @@ export class HierarchyComponent {
 
   constructor(public hierarchy: HierarchyService) {}
   ngOnInit() {
-    this.main_river_basin = ''
+    this.main_river_basin = '';
     if (this.main_rb_name != null) {
       this.main_river_basin = this.main_rb_name;
     } else {
-      this.main_river_basin = 'aucun'
+      this.main_river_basin = 'aucun';
     }
   }
 }

--- a/frontend/app/zh-details/hierarchy/hierarchy.component.ts
+++ b/frontend/app/zh-details/hierarchy/hierarchy.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { HierarchyModel } from '../models/hierarchy.model';
+import { HierarchyTotalModel } from '../models/hierarchy.model';
 import { HierarchyService } from '../../services/hierarchy.service';
 
 @Component({
@@ -8,11 +8,17 @@ import { HierarchyService } from '../../services/hierarchy.service';
   styleUrls: ['./hierarchy.component.scss'],
 })
 export class HierarchyComponent {
-  @Input() data: HierarchyModel;
+  @Input() data: HierarchyTotalModel;
+  main_river_basin_name: string;
 
   constructor(public hierarchy: HierarchyService) {}
-
   ngOnInit() {
-    this.hierarchy.setItems(this.data);
+    this.main_river_basin_name = ''
+    if (this.data.main_basin_name != null) {
+      this.main_river_basin_name = this.data.main_basin_name;
+      this.hierarchy.setItems(this.data.hierarchy);
+    } else {
+      this.main_river_basin_name = 'aucun'
+    }
   }
 }

--- a/frontend/app/zh-details/models/hierarchy.model.ts
+++ b/frontend/app/zh-details/models/hierarchy.model.ts
@@ -1,5 +1,9 @@
+export interface HierarchyTotalModel {
+  main_basin_name: string;
+  hierarchy: HierarchyModel;
+}
+
 export interface HierarchyModel {
-  river_basin_name: string;
   volet1: Volet1;
   volet2: Volet2;
   global_note: string;

--- a/frontend/app/zh-details/statuts/statuts.component.ts
+++ b/frontend/app/zh-details/statuts/statuts.component.ts
@@ -43,8 +43,7 @@ export class StatutsComponent implements OnInit {
     { name: 'duree', label: 'Durée (années)' },
     { name: 'remark', label: 'Remarques' },
   ];
-  constructor(public config: ConfigService) {
-  }
+  constructor(public config: ConfigService) {}
 
   ngOnInit() {
     var groupBy = function (xs, key) {

--- a/frontend/app/zh-details/statuts/statuts.component.ts
+++ b/frontend/app/zh-details/statuts/statuts.component.ts
@@ -44,7 +44,6 @@ export class StatutsComponent implements OnInit {
     { name: 'remark', label: 'Remarques' },
   ];
   constructor(public config: ConfigService) {
-    console.log(config);
   }
 
   ngOnInit() {

--- a/frontend/app/zh-details/zh-details.component.html
+++ b/frontend/app/zh-details/zh-details.component.html
@@ -29,7 +29,7 @@
     #accordion="matAccordion"
     [multi]="true"
   >
-    <!-- Attention : bien mettre entre crochet title et les strings entre '' 
+    <!-- Attention : bien mettre entre crochet title et les strings entre ''
         sinon génère un tooltip native (title) dans le collapse -->
     <collapse
       [title]="'1. Renseignements généraux'"
@@ -84,7 +84,6 @@
       [expanded]="expanded"
     >
       <zh-details-hierarchy
-        [data]="hierarchy"
         [main_rb_name]="currentZh.properties.main_rb_name"
       ></zh-details-hierarchy>
     </collapse>

--- a/frontend/app/zh-details/zh-details.component.html
+++ b/frontend/app/zh-details/zh-details.component.html
@@ -83,7 +83,10 @@
       [title]="'9. Hiérarchisation'"
       [expanded]="expanded"
     >
-      <zh-details-hierarchy [data]="hierarchy" [main_rb_name]="currentZh.properties.main_rb_name"></zh-details-hierarchy>
+      <zh-details-hierarchy
+        [data]="hierarchy"
+        [main_rb_name]="currentZh.properties.main_rb_name"
+      ></zh-details-hierarchy>
     </collapse>
   </mat-accordion>
 </div>

--- a/frontend/app/zh-details/zh-details.component.ts
+++ b/frontend/app/zh-details/zh-details.component.ts
@@ -48,7 +48,7 @@ export class ZhDetailsComponent implements OnInit, AfterViewInit {
     this._zhService.getZhById(this.id_zh).subscribe((zh: any) => {
       if (zh) {
         this.currentZh = zh;
-        this.hierarchy.getHierarchy(zh.id)
+        this.hierarchy.getHierarchy(zh.id);
       }
     });
   }

--- a/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.html
+++ b/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.html
@@ -1,19 +1,25 @@
 <div class="container-fluid">
   <h2 class="tabsTitle">Hiérarchisation</h2>
 
-    <h4 class="tabsSubtitle">Bassin versant principal 
-      <i class="fa fa-info-circle"></i> 
-      <span class="tip-txt">
-        Une zone humide peut intersecter plusieurs bassins versants. Le bassin versant principal est celui qui couvre le plus de surface sur la zone humide. Le calcul de la hiérarchisation d'une zone humide se base UNIQUEMENT sur les règles du bassin versant principal. Pour avoir une liste complète de tous les bassins versants intersectés par une zone humide, voir l'onglet 3 de la fiche complète.
-      </span> : {{ main_rb_name }}
-    </h4>
+  <h4 class="tabsSubtitle">
+    Bassin versant principal
+    <i class="fa fa-info-circle"></i>
+    <span class="tip-txt">
+      Une zone humide peut intersecter plusieurs bassins versants. Le bassin versant principal est
+      celui qui couvre le plus de surface sur la zone humide. Le calcul de la hiérarchisation d'une
+      zone humide se base UNIQUEMENT sur les règles du bassin versant principal. Pour avoir une
+      liste complète de tous les bassins versants intersectés par une zone humide, voir l'onglet 3
+      de la fiche complète.
+    </span>
+    : {{ main_rb_name }}
+  </h4>
 
-    <div
-      *ngIf="hierarchy.warning"
-      class="alert alert-warning mat-alert"
-    >
-      {{ hierarchy.warning }}
-    </div>
+  <div
+    *ngIf="hierarchy.warning"
+    class="alert alert-warning mat-alert"
+  >
+    {{ hierarchy.warning }}
+  </div>
 
   <div *ngIf="!hierarchy.isLoading && main_rb_name != 'aucun'">
     <zh-table

--- a/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.html
+++ b/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.html
@@ -1,9 +1,14 @@
 <div class="container-fluid">
   <h2 class="tabsTitle">Hiérarchisation</h2>
 
-  <div *ngIf="!hierarchy.isLoading">
-    <h4 class="tabsSubtitle">Bassin versant : {{ hierarchy.rb_name }}</h4>
+    <h4 class="tabsSubtitle">Bassin versant principal 
+      <i class="fa fa-info-circle"></i> 
+      <span class="tip-txt">
+        Une zone humide peut intersecter plusieurs bassins versants. Le bassin versant principal est celui qui couvre le plus de surface sur la zone humide. Le calcul de la hiérarchisation d'une zone humide se base UNIQUEMENT sur les règles du bassin versant principal. Pour avoir une liste complète de tous les bassins versants intersectés par une zone humide, voir l'onglet 3 de la fiche complète.
+      </span> : {{ main_rb_name }}
+    </h4>
 
+  <div *ngIf="!hierarchy.isLoading && main_rb_name != 'aucun'">
     <zh-table
       [tableCols]="hierarchy.hierTableCols"
       [data]="hierarchy.items"

--- a/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.scss
+++ b/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.scss
@@ -37,7 +37,7 @@ select.custom-select option:disabled {
 .fa {
   font-size: 14px;
 }
-.fa-info-circle:hover + .tip-txt { 
+.fa-info-circle:hover + .tip-txt {
   visibility: visible;
   color: rgb(255, 255, 255);
   opacity: 1;

--- a/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.scss
+++ b/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.scss
@@ -33,6 +33,7 @@ select.custom-select option:disabled {
   border-radius: 3px;
   box-sizing: border-box;
   text-align: justify;
+  z-index: 999;
 }
 .fa {
   font-size: 14px;

--- a/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.scss
+++ b/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.scss
@@ -23,3 +23,22 @@ select.custom-select option:disabled {
     margin-left: 2px;
   }
 }
+.tip-txt {
+  width: 300px;
+  position: absolute;
+  visibility: hidden;
+  background: #757171;
+  padding: 10px;
+  font-size: 12px;
+  border-radius: 3px;
+  box-sizing: border-box;
+  text-align: justify;
+}
+.fa {
+  font-size: 14px;
+}
+.fa-info-circle:hover + .tip-txt { 
+  visibility: visible;
+  color: rgb(255, 255, 255);
+  opacity: 1;
+}

--- a/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.ts
+++ b/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.ts
@@ -41,7 +41,7 @@ export class ZhFormTab9Component implements OnInit {
           this.main_rb_name = zh.properties.main_rb_name;
           this.hierarchy.getHierarchy(zh.id);
         } else {
-          this.main_rb_name = "aucun";
+          this.main_rb_name = 'aucun';
         }
       }
     });

--- a/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.ts
+++ b/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.ts
@@ -15,6 +15,7 @@ export class ZhFormTab9Component implements OnInit {
   public $_fromChangeSub: Subscription;
   public $_getTabChangeSub: Subscription;
   public currentZh: any;
+  public main_rb_name: string;
 
   constructor(
     private _dataService: ZhDataService,
@@ -36,8 +37,12 @@ export class ZhFormTab9Component implements OnInit {
   getCurrentZh() {
     this.$_currentZhSub = this._dataService.currentZh.subscribe((zh: any) => {
       if (zh) {
-        this.currentZh = zh;
-        this.hierarchy.getHierarchy(zh.id, zh.properties.bassin_versant);
+        if (zh.properties.main_rb_name != null) {
+          this.main_rb_name = zh.properties.main_rb_name;
+          this.hierarchy.getHierarchy(zh.id);
+        } else {
+          this.main_rb_name = "aucun";
+        }
       }
     });
   }

--- a/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.ts
+++ b/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.ts
@@ -51,5 +51,6 @@ export class ZhFormTab9Component implements OnInit {
   ngOnDestroy() {
     if (this.$_getTabChangeSub) this.$_getTabChangeSub.unsubscribe();
     if (this.$_currentZhSub) this.$_currentZhSub.unsubscribe();
+    this.hierarchy.warning = '';
   }
 }


### PR DESCRIPTION
- Améliore l'affichage du nom du bassin versant onglet 9 : 
   - affiche seulement le nom du bassin versant principal (la hiérarchisation étant seulement calculée sur le bassin versant principal)
   - affiche une explication (i) sur les bassins versants liés à la ZH
   - nom du bassin versant affiché même lorsque la hiérarchisation ne peut pas être calculée : la détermination du bassin versant principal est donc sorti du calcul des règles de hiérarchisation et fait en amont (main_id_rb passé en paramètre pour le calcul des règles) et stocké en bdd (pr_zh.main_id_rb)
   - abandon du toaster lors d'une erreur pendant le calcul de la hiérarchie du bassin versant : à la place l'erreur est clairement affichée sous le nom du bassin versant. Exemple : 
![image](https://github.com/user-attachments/assets/accba2c0-808b-496f-afe1-9a8a47234c88)
   - si aucun bassin versant n'est associé en bdd à une ZH, "aucun" est indiqué : 
![image](https://github.com/user-attachments/assets/013d730b-91ee-4412-bd4d-c87d7957517d)

- Ces améliorations sont répercutées aussi dans la fiche principale onglet 9

- 2 migrations alembic associées à ces changements pour ajouter et remplir une colonne pr_zh.main_id_rb

- Quelques erreurs sqlalchemy liées aux bassins versants et zones hydro corrigées au passage (dont l'erreur sur les zones hydro signalée ici : https://github.com/PnX-SI/gn_module_ZH/pull/93)