### PR TITLE
drop useless insee_regions table

### DIFF
--- a/backend/gn_module_zh/migrations/da5b95b24f06_drop_ref_geo_insee_regions.py
+++ b/backend/gn_module_zh/migrations/da5b95b24f06_drop_ref_geo_insee_regions.py
@@ -1,0 +1,55 @@
+"""drop ref_geo.insee_regions
+
+Revision ID: da5b95b24f06
+Revises: 72a8378567pa
+Create Date: 2024-12-13 16:16:43.446953
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "da5b95b24f06"
+down_revision = "72a8378567pa"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_table(table_name="insee_regions", schema="ref_geo")
+
+
+def downgrade():
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ref_geo.insee_regions (
+            insee_reg varchar(2) NOT NULL, 
+            region_name varchar(50) NOT NULL,
+            CONSTRAINT pk_insee_regions_insee_code PRIMARY KEY ( insee_reg ),
+            CONSTRAINT unq_insee_region_name UNIQUE ( region_name ) 
+        );
+
+        INSERT INTO ref_geo.insee_regions(insee_reg,region_name) VALUES
+            ('01','Guadeloupe'),
+            ('02','Martinique'),
+            ('03','Guyane'),
+            ('04','La Réunion'),
+            ('06','Mayotte'),
+            ('11','Île-de-France'),
+            ('24','Centre-Val de Loire'),
+            ('27','Bourgogne-Franche-Comté'),
+            ('28','Normandie'),
+            ('32','Hauts-de-France'),
+            ('44','Grand Est'),
+            ('52','Pays de la Loire'),
+            ('53','Bretagne'),
+            ('75','Nouvelle-Aquitaine'),
+            ('76','Occitanie'),
+            ('84','Auvergne-Rhône-Alpes'),
+            ('93','Provence-Alpes-Côte d''Azur'),
+            ('94','Corse')
+            ON CONFLICT (insee_reg) DO NOTHING
+        ;
+        """
+    )

--- a/backend/gn_module_zh/migrations/da5b95b24f06_drop_ref_geo_insee_regions.py
+++ b/backend/gn_module_zh/migrations/da5b95b24f06_drop_ref_geo_insee_regions.py
@@ -5,6 +5,7 @@ Revises: 72a8378567pa
 Create Date: 2024-12-13 16:16:43.446953
 
 """
+
 from alembic import op
 import sqlalchemy as sa
 

--- a/backend/gn_module_zh/model/zh.py
+++ b/backend/gn_module_zh/model/zh.py
@@ -1,6 +1,8 @@
 # instance de la BDD
 from geonature.utils.env import DB
+from sqlalchemy import and_
 from sqlalchemy.sql import select
+from ref_geo.models import BibAreasTypes, LAreas
 
 from .zh_schema import (
     TZH,
@@ -14,7 +16,6 @@ from .zh_schema import (
     CorZhLimFs,
     CorZhProtection,
     CorZhRef,
-    InseeRegions,
     TActions,
     TActivity,
     TFunctions,
@@ -255,9 +256,15 @@ class ZH(TZH):
             if municipality.LiMunicipalities.insee_reg not in region_list:
                 region_list.append(municipality.LiMunicipalities.insee_reg)
         q_region = DB.session.scalars(
-            select(InseeRegions).where(InseeRegions.insee_reg.in_(region_list))
+            select(LAreas)
+            .select_from(LAreas, BibAreasTypes)
+            .where(
+                and_(LAreas.area_code.in_(region_list)),
+                LAreas.id_type == BibAreasTypes.id_type,
+                BibAreasTypes.type_name == "Régions",
+            )
         ).all()
-        regions = [region.region_name for region in q_region]
+        regions = [region.area_name for region in q_region]
         return regions
 
     def get_area(self):

--- a/backend/gn_module_zh/model/zh.py
+++ b/backend/gn_module_zh/model/zh.py
@@ -256,12 +256,12 @@ class ZH(TZH):
             if municipality.LiMunicipalities.insee_reg not in region_list:
                 region_list.append(municipality.LiMunicipalities.insee_reg)
         q_region = DB.session.scalars(
-            select(LAreas)
-            .select_from(LAreas, BibAreasTypes)
-            .where(
-                and_(LAreas.area_code.in_(region_list)),
-                LAreas.id_type == BibAreasTypes.id_type,
-                BibAreasTypes.type_name == "Régions",
+            select(LAreas, BibAreasTypes).where(
+                and_(
+                    LAreas.area_code.in_(region_list),
+                    LAreas.id_type == BibAreasTypes.id_type,
+                    BibAreasTypes.type_name == "Régions",
+                )
             )
         ).all()
         regions = [region.area_name for region in q_region]

--- a/backend/gn_module_zh/model/zh_schema.py
+++ b/backend/gn_module_zh/model/zh_schema.py
@@ -885,13 +885,6 @@ class CorZhProtection(DB.Model):
     id_zh = DB.Column(DB.Integer, ForeignKey(TZH.id_zh), primary_key=True)
 
 
-class InseeRegions(DB.Model):
-    __tablename__ = "insee_regions"
-    __table_args__ = {"schema": "ref_geo"}
-    insee_reg = DB.Column(DB.Unicode(length=2), primary_key=True)
-    region_name = DB.Column(DB.Unicode(length=50), nullable=False)
-
-
 class TManagementStructures(DB.Model):
     __tablename__ = "t_management_structures"
     __table_args__ = {"schema": "pr_zh"}


### PR DESCRIPTION
La table ref_geo.insee_regions créée au moment de l'installation du module n'est plus utile, toutes les infos sont dans ref_geo.l_areas : 
- migration alembic de suppression de la table
- suppression de la table dans le modèle
- requetes sqlalchemy modifiées
