### PR TITLE
fix: municipality name in urban docs for cards

### DIFF
--- a/backend/gn_module_zh/model/cards.py
+++ b/backend/gn_module_zh/model/cards.py
@@ -809,7 +809,7 @@ class UrbanDoc:
 
     def __str__(self):
         return {
-            "commune": DB.session.get(LAreas, self.id_area).id_area,
+            "commune": DB.session.get(LAreas, self.id_area).area_name,
             "type_doc": Utils.get_mnemo(self.id_doc_type),
             "type_classement": [
                 Utils.get_mnemo(


### PR DESCRIPTION
fix d'une erreur d'affichage de nom de communes dans les documents d'urbanisme décrite ici : #96 
