### PR TITLE
correction d'erreurs de mises à jour des notes

### DIFF
--- a/backend/gn_module_zh/blueprint.py
+++ b/backend/gn_module_zh/blueprint.py
@@ -522,6 +522,20 @@ def delete_one_zh_notes(id_zh):
         DB.session.close()
 
 
+@blueprint.route("/all/hierarchy", methods=["GET"])
+@permissions.check_cruved_scope("C", module_code="ZONES_HUMIDES")
+@json_resp
+def generate_all_notes():
+    result = DB.session.scalars(select(TZH.id_zh)).all()
+    if result:
+        for id_zh in result:
+            try:
+                get_hierarchy(id_zh)
+            except Exception as e:
+                pass
+    return ("", 204)
+
+
 @blueprint.route("files/<int:id_media>", methods=["GET"])
 @permissions.check_cruved_scope("C", module_code="ZONES_HUMIDES")
 def download_file(id_media):

--- a/backend/gn_module_zh/blueprint.py
+++ b/backend/gn_module_zh/blueprint.py
@@ -27,7 +27,7 @@ from utils_flask_sqla.generic import GenericQuery
 from utils_flask_sqla.response import json_resp_accept_empty_list, json_resp
 
 from .api_error import ZHApiError
-from . import tasks  # noqa: F401
+
 from .forms import (
     create_zh,
     post_file_info,
@@ -52,8 +52,7 @@ from .forms import (
     update_zh_tab6,
 )
 
-# from .forms import *
-from .geometry import set_area, set_geom, get_main_rb
+from .geometry import set_area, set_geom
 from .hierarchy import Hierarchy, get_all_hierarchy_fields
 from .model.cards import Card
 from .model.repositories import ZhRepository
@@ -83,7 +82,6 @@ from .utils import (
     get_user_cruved,
     delete_notes,
 )
-import gn_module_zh.tasks
 
 blueprint = Blueprint("pr_zh", __name__, "./static", template_folder="templates")
 
@@ -523,7 +521,6 @@ def delete_one_zh_notes(id_zh):
 
 
 @blueprint.route("/all/hierarchy", methods=["GET"])
-@permissions.check_cruved_scope("C", module_code="ZONES_HUMIDES")
 @json_resp
 def generate_all_notes():
     result = DB.session.scalars(select(TZH.id_zh)).all()

--- a/backend/gn_module_zh/blueprint.py
+++ b/backend/gn_module_zh/blueprint.py
@@ -81,6 +81,7 @@ from .utils import (
     get_last_pdf_export,
     get_main_picture_id,
     get_user_cruved,
+    delete_notes,
 )
 import gn_module_zh.tasks
 
@@ -501,6 +502,22 @@ def delete_one_file(id_media):
         if e.__class__.__name__ == "ZHApiError":
             raise ZHApiError(message=str(e.message), details=str(e.details))
         raise ZHApiError(message="delete_one_file_error", details=str(e))
+    finally:
+        DB.session.close()
+
+
+@blueprint.route("notes/<int:id_zh>", methods=["DELETE"])
+@json_resp
+@permissions.check_cruved_scope("D", module_code="ZONES_HUMIDES")
+def delete_one_zh_notes(id_zh):
+    """delete all hierarchy notes for one zh"""
+    try:
+        delete_notes(id_zh)
+    except Exception as e:
+        DB.session.rollback()
+        if e.__class__.__name__ == "ZHApiError":
+            raise ZHApiError(message=str(e.message), details=str(e.details))
+        raise ZHApiError(message="delete_notes_error", details=str(e))
     finally:
         DB.session.close()
 

--- a/backend/gn_module_zh/tasks.py
+++ b/backend/gn_module_zh/tasks.py
@@ -1,8 +1,3 @@
-import os
-
-from datetime import datetime, timedelta
-from pathlib import Path
-
 from sqlalchemy import func, text
 from celery.utils.log import get_task_logger
 from celery.schedules import crontab
@@ -12,6 +7,8 @@ from geonature.utils.celery import celery_app
 
 from geonature.utils.env import db
 from geonature.utils.config import config
+
+from .blueprint import generate_all_notes
 
 logger = get_task_logger(__name__)
 
@@ -49,6 +46,22 @@ def setup_periodic_tasks_for_vm_rb_rules(sender, **kwargs):
     )
 
 
+@celery_app.on_after_finalize.connect
+def setup_periodic_tasks_update_notes(sender, **kwargs):
+    minute, hour, day_of_month, month_of_year, day_of_week = "* * * * *".split(" ")
+    sender.add_periodic_task(
+        crontab(
+            minute=minute,
+            hour=hour,
+            day_of_week=day_of_week,
+            day_of_month=day_of_month,
+            month_of_year=month_of_year,
+        ),
+        execute_generate_all_notes.s(),
+        name="Update_all_notes...",
+    )
+
+
 @celery_app.task(bind=True)
 def refresh_taxon_vm(self):
     logger.info("Refresh taxon vms...")
@@ -63,3 +76,10 @@ def refresh_vm_rb_rules(self):
     db.session.execute(text("REFRESH MATERIALIZED VIEW pr_zh.rb_notes_summary"))
     db.session.commit()
     logger.info("vm rb rules refreshed.")
+
+
+@celery_app.task(bind=True)
+def execute_generate_all_notes(self):
+    logger.info("Update_all_notes...")
+    generate_all_notes()
+    logger.info("all notes updated...")

--- a/backend/gn_module_zh/utils.py
+++ b/backend/gn_module_zh/utils.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Query
 from sqlalchemy.sql import select, update, delete, func
 
 from .api_error import ZHApiError
-from .model.zh_schema import TZH, BibAreasTypes, LAreas
+from .model.zh_schema import TZH, BibAreasTypes, LAreas, CorZhNotes
 
 
 def get_main_picture_id(id_zh, media_list=None):
@@ -88,6 +88,15 @@ def delete_file(id_media):
         raise ZHApiError(
             message="delete_file_error", details=str(exc_type) + ": " + str(e.with_traceback(tb))
         )
+
+
+def delete_notes(id_zh):
+    notes_to_delete = DB.session.execute(
+        select(CorZhNotes).where(CorZhNotes.id_zh == id_zh)
+    ).scalars()
+    for note in notes_to_delete:
+        DB.session.delete(note)
+    DB.session.commit()
 
 
 def check_ref_geo_schema():

--- a/frontend/app/services/hierarchy.service.ts
+++ b/frontend/app/services/hierarchy.service.ts
@@ -64,9 +64,8 @@ export class HierarchyService {
         () => {
           this.isLoading = false;
         }
-    );
+      );
   }
-
 
   deleteNotes(idZH: number) {
     return this._dataService.deleteNotes(idZH).subscribe();

--- a/frontend/app/services/hierarchy.service.ts
+++ b/frontend/app/services/hierarchy.service.ts
@@ -37,6 +37,12 @@ export class HierarchyService {
     this.isLoading = false;
   }
 
+  getHierarchyFromZh(zh) {
+    if (zh.properties.main_id_rb) {
+      this.getHierarchy(zh.properties.id_zh);
+    }
+  }
+
   // get current zone humides
   getHierarchy(zhId) {
     this.isLoading = true;

--- a/frontend/app/services/hierarchy.service.ts
+++ b/frontend/app/services/hierarchy.service.ts
@@ -37,6 +37,10 @@ export class HierarchyService {
     this.isLoading = false;
   }
 
+  clear(): void {
+    this.warning = '';
+  }
+
   getHierarchyFromZh(zh) {
     if (zh.properties.main_id_rb) {
       this.getHierarchy(zh.properties.id_zh);

--- a/frontend/app/services/hierarchy.service.ts
+++ b/frontend/app/services/hierarchy.service.ts
@@ -59,11 +59,17 @@ export class HierarchyService {
               (i) => error.error['message'] === i.api
             )[0].front;
           }
+          this.deleteNotes(zhId);
         },
         () => {
           this.isLoading = false;
         }
-      );
+    );
+  }
+
+
+  deleteNotes(idZH: number) {
+    return this._dataService.deleteNotes(idZH).subscribe();
   }
 
   // set list of hierarchy items

--- a/frontend/app/services/zh-data.service.ts
+++ b/frontend/app/services/zh-data.service.ts
@@ -121,6 +121,10 @@ export class ZhDataService {
     });
   }
 
+  deleteNotes(zhId: number) {
+    return this._api.delete(`${this.config.API_ENDPOINT}/zones_humides/notes/${zhId}`);
+  }
+
   getPdf(zhId: number) {
     return this._api.get(`${this.config.API_ENDPOINT}/zones_humides/export_pdf/${zhId}`, {
       responseType: 'blob',

--- a/frontend/app/zh-forms/tabs/tab0/zh-form-tab0.component.ts
+++ b/frontend/app/zh-forms/tabs/tab0/zh-form-tab0.component.ts
@@ -211,10 +211,7 @@ export class ZhFormTab0Component implements OnInit {
                 closeButton: true,
                 positionClass: 'toast-top-right',
               });
-              console.log(this._currentZh);
-              if (this._currentZh.properties.main_id_rb) {
-                this.hierarchy.getHierarchy(this._currentZh.properties.id_zh);
-              }
+              this.hierarchy.getHierarchyFromZh(this._currentZh);
               this.nextTab.emit(1);
             });
           },

--- a/frontend/app/zh-forms/tabs/tab0/zh-form-tab0.component.ts
+++ b/frontend/app/zh-forms/tabs/tab0/zh-form-tab0.component.ts
@@ -10,6 +10,7 @@ import { ZhDataService } from '../../../services/zh-data.service';
 import { TabsService } from '../../../services/tabs.service';
 import { ErrorTranslatorService } from '../../../services/error-translator.service';
 import { PbfService } from '../../../services/pbf.service';
+import { HierarchyService } from '../../../services/hierarchy.service';
 
 const GEOM_CONTAINED_ID = 1;
 
@@ -47,7 +48,8 @@ export class ZhFormTab0Component implements OnInit {
     private _router: Router,
     private _toastr: ToastrService,
     private _error: ErrorTranslatorService,
-    private _pbfService: PbfService
+    private _pbfService: PbfService,
+    public hierarchy: HierarchyService
   ) {}
 
   ngOnInit() {
@@ -209,6 +211,10 @@ export class ZhFormTab0Component implements OnInit {
                 closeButton: true,
                 positionClass: 'toast-top-right',
               });
+              console.log(this._currentZh);
+              if (this._currentZh.properties.main_id_rb) {
+                this.hierarchy.getHierarchy(this._currentZh.properties.id_zh);
+              }
               this.nextTab.emit(1);
             });
           },
@@ -281,6 +287,7 @@ export class ZhFormTab0Component implements OnInit {
   ngOnDestroy() {
     if (this.$_geojsonSub) this.$_geojsonSub.unsubscribe();
     if (this.$_currentZhSub) this.$_currentZhSub.unsubscribe();
+    this.hierarchy.warning = '';
   }
 
   featureCollectionToMultipolygon(featureCollection) {

--- a/frontend/app/zh-forms/tabs/tab0/zh-form-tab0.component.ts
+++ b/frontend/app/zh-forms/tabs/tab0/zh-form-tab0.component.ts
@@ -284,7 +284,7 @@ export class ZhFormTab0Component implements OnInit {
   ngOnDestroy() {
     if (this.$_geojsonSub) this.$_geojsonSub.unsubscribe();
     if (this.$_currentZhSub) this.$_currentZhSub.unsubscribe();
-    this.hierarchy.warning = '';
+    this.hierarchy.clear();
   }
 
   featureCollectionToMultipolygon(featureCollection) {

--- a/frontend/app/zh-forms/tabs/tab1/zh-form-tab1.component.ts
+++ b/frontend/app/zh-forms/tabs/tab1/zh-form-tab1.component.ts
@@ -161,9 +161,7 @@ export class ZhFormTab1Component implements OnInit {
             this._toastr.success('Vos données sont bien enregistrées', '', {
               positionClass: 'toast-top-right',
             });
-            if (this.currentZh.properties.main_id_rb) {
-              this.hierarchy.getHierarchy(this.currentZh.properties.id_zh);
-            }
+            this.hierarchy.getHierarchyFromZh(this.currentZh);
             this.nextTab.emit(2);
           });
         },

--- a/frontend/app/zh-forms/tabs/tab1/zh-form-tab1.component.ts
+++ b/frontend/app/zh-forms/tabs/tab1/zh-form-tab1.component.ts
@@ -199,6 +199,6 @@ export class ZhFormTab1Component implements OnInit {
   ngOnDestroy() {
     if (this.$_currentZhSub) this.$_currentZhSub.unsubscribe();
     this.ngbModal.dismissAll();
-    this.hierarchy.warning = '';
+    this.hierarchy.clear();
   }
 }

--- a/frontend/app/zh-forms/tabs/tab1/zh-form-tab1.component.ts
+++ b/frontend/app/zh-forms/tabs/tab1/zh-form-tab1.component.ts
@@ -8,6 +8,7 @@ import { ZhDataService } from '../../../services/zh-data.service';
 import { TabsService } from '../../../services/tabs.service';
 import { ErrorTranslatorService } from '../../../services/error-translator.service';
 import { ConfigService } from '@geonature/services/config.service';
+import { HierarchyService } from '../../../services/hierarchy.service';
 
 @Component({
   selector: 'zh-form-tab1',
@@ -47,7 +48,8 @@ export class ZhFormTab1Component implements OnInit {
     private _tabService: TabsService,
     private _error: ErrorTranslatorService,
     public ngbModal: NgbModal,
-    private _config: ConfigService
+    private _config: ConfigService,
+    public hierarchy: HierarchyService
   ) {}
 
   ngOnInit() {
@@ -159,6 +161,9 @@ export class ZhFormTab1Component implements OnInit {
             this._toastr.success('Vos données sont bien enregistrées', '', {
               positionClass: 'toast-top-right',
             });
+            if (this.currentZh.properties.main_id_rb) {
+              this.hierarchy.getHierarchy(this.currentZh.properties.id_zh);
+            }
             this.nextTab.emit(2);
           });
         },
@@ -196,5 +201,6 @@ export class ZhFormTab1Component implements OnInit {
   ngOnDestroy() {
     if (this.$_currentZhSub) this.$_currentZhSub.unsubscribe();
     this.ngbModal.dismissAll();
+    this.hierarchy.warning = '';
   }
 }

--- a/frontend/app/zh-forms/tabs/tab2/zh-form-tab2.component.ts
+++ b/frontend/app/zh-forms/tabs/tab2/zh-form-tab2.component.ts
@@ -141,6 +141,6 @@ export class ZhFormTab2Component implements OnInit, AfterViewInit {
   ngOnDestroy() {
     if (this.$_currentZhSub) this.$_currentZhSub.unsubscribe();
     if (this.$_fromChangeSub) this.$_fromChangeSub.unsubscribe();
-    this.hierarchy.warning = '';
+    this.hierarchy.clear();
   }
 }

--- a/frontend/app/zh-forms/tabs/tab2/zh-form-tab2.component.ts
+++ b/frontend/app/zh-forms/tabs/tab2/zh-form-tab2.component.ts
@@ -5,6 +5,7 @@ import { Subscription } from 'rxjs';
 import { ErrorTranslatorService } from '../../../services/error-translator.service';
 import { TabsService } from '../../../services/tabs.service';
 import { ZhDataService } from '../../../services/zh-data.service';
+import { HierarchyService } from '../../../services/hierarchy.service';
 
 @Component({
   selector: 'zh-form-tab2',
@@ -29,7 +30,8 @@ export class ZhFormTab2Component implements OnInit, AfterViewInit {
     private _dataService: ZhDataService,
     private _toastr: ToastrService,
     private _error: ErrorTranslatorService,
-    private _tabService: TabsService
+    private _tabService: TabsService,
+    public hierarchy: HierarchyService
   ) {}
 
   ngOnInit() {
@@ -121,6 +123,12 @@ export class ZhFormTab2Component implements OnInit, AfterViewInit {
             this._toastr.success('Vos données sont bien enregistrées', '', {
               positionClass: 'toast-top-right',
             });
+            if (this.currentZh.properties.main_id_rb) {
+              this.hierarchy.getHierarchy(this.currentZh.properties.id_zh);
+            }
+            if (this.currentZh.properties.main_id_rb) {
+              this.hierarchy.getHierarchy(this.currentZh.properties.id_zh);
+            }
             this.nextTab.emit(3);
           });
         },
@@ -138,5 +146,6 @@ export class ZhFormTab2Component implements OnInit, AfterViewInit {
   ngOnDestroy() {
     if (this.$_currentZhSub) this.$_currentZhSub.unsubscribe();
     if (this.$_fromChangeSub) this.$_fromChangeSub.unsubscribe();
+    this.hierarchy.warning = '';
   }
 }

--- a/frontend/app/zh-forms/tabs/tab2/zh-form-tab2.component.ts
+++ b/frontend/app/zh-forms/tabs/tab2/zh-form-tab2.component.ts
@@ -123,12 +123,7 @@ export class ZhFormTab2Component implements OnInit, AfterViewInit {
             this._toastr.success('Vos données sont bien enregistrées', '', {
               positionClass: 'toast-top-right',
             });
-            if (this.currentZh.properties.main_id_rb) {
-              this.hierarchy.getHierarchy(this.currentZh.properties.id_zh);
-            }
-            if (this.currentZh.properties.main_id_rb) {
-              this.hierarchy.getHierarchy(this.currentZh.properties.id_zh);
-            }
+            this.hierarchy.getHierarchyFromZh(this.currentZh);
             this.nextTab.emit(3);
           });
         },

--- a/frontend/app/zh-forms/tabs/tab3/zh-form-tab3.component.ts
+++ b/frontend/app/zh-forms/tabs/tab3/zh-form-tab3.component.ts
@@ -8,6 +8,7 @@ import { ToastrService } from 'ngx-toastr';
 import { TabsService } from '../../../services/tabs.service';
 import { ModalService } from '../../../services/modal.service';
 import { ErrorTranslatorService } from '../../../services/error-translator.service';
+import { HierarchyService } from '../../../services/hierarchy.service';
 
 @Component({
   selector: 'zh-form-tab3',
@@ -91,7 +92,8 @@ export class ZhFormTab3Component implements OnInit {
     public ngbModal: NgbModal,
     private _modalService: ModalService,
     private _error: ErrorTranslatorService,
-    private _toastr: ToastrService
+    private _toastr: ToastrService,
+    public hierarchy: HierarchyService
   ) {}
 
   ngOnInit() {
@@ -423,6 +425,9 @@ export class ZhFormTab3Component implements OnInit {
             this._toastr.success('Vos données sont bien enregistrées', '', {
               positionClass: 'toast-top-right',
             });
+            if (this.currentZh.properties.main_id_rb) {
+              this.hierarchy.getHierarchy(this.currentZh.properties.id_zh);
+            }
             this.nextTab.emit(4);
           });
         },
@@ -468,5 +473,6 @@ export class ZhFormTab3Component implements OnInit {
   ngOnDestroy() {
     if (this.$_currentZhSub) this.$_currentZhSub.unsubscribe();
     if (this.$_fromChangeSub) this.$_fromChangeSub.unsubscribe();
+    this.hierarchy.warning = '';
   }
 }

--- a/frontend/app/zh-forms/tabs/tab3/zh-form-tab3.component.ts
+++ b/frontend/app/zh-forms/tabs/tab3/zh-form-tab3.component.ts
@@ -471,6 +471,6 @@ export class ZhFormTab3Component implements OnInit {
   ngOnDestroy() {
     if (this.$_currentZhSub) this.$_currentZhSub.unsubscribe();
     if (this.$_fromChangeSub) this.$_fromChangeSub.unsubscribe();
-    this.hierarchy.warning = '';
+    this.hierarchy.clear();
   }
 }

--- a/frontend/app/zh-forms/tabs/tab3/zh-form-tab3.component.ts
+++ b/frontend/app/zh-forms/tabs/tab3/zh-form-tab3.component.ts
@@ -425,9 +425,7 @@ export class ZhFormTab3Component implements OnInit {
             this._toastr.success('Vos données sont bien enregistrées', '', {
               positionClass: 'toast-top-right',
             });
-            if (this.currentZh.properties.main_id_rb) {
-              this.hierarchy.getHierarchy(this.currentZh.properties.id_zh);
-            }
+            this.hierarchy.getHierarchyFromZh(this.currentZh);
             this.nextTab.emit(4);
           });
         },

--- a/frontend/app/zh-forms/tabs/tab4/zh-form-tab4.component.ts
+++ b/frontend/app/zh-forms/tabs/tab4/zh-form-tab4.component.ts
@@ -7,6 +7,8 @@ import { ZhDataService } from '../../../services/zh-data.service';
 import { TabsService } from '../../../services/tabs.service';
 import { ModalService } from '../../../services/modal.service';
 import { ErrorTranslatorService } from '../../../services/error-translator.service';
+import { HierarchyService } from '../../../services/hierarchy.service';
+
 @Component({
   selector: 'zh-form-tab4',
   templateUrl: './zh-form-tab4.component.html',
@@ -99,7 +101,8 @@ export class ZhFormTab4Component implements OnInit {
     private _dataService: ZhDataService,
     private _modalService: ModalService,
     private _error: ErrorTranslatorService,
-    private _tabService: TabsService
+    private _tabService: TabsService,
+    public hierarchy: HierarchyService
   ) {}
 
   ngOnInit() {
@@ -456,6 +459,9 @@ export class ZhFormTab4Component implements OnInit {
             this._toastr.success('Vos données sont bien enregistrées', '', {
               positionClass: 'toast-top-right',
             });
+            if (this.currentZh.properties.main_id_rb) {
+              this.hierarchy.getHierarchy(this.currentZh.properties.id_zh);
+            }
             this.nextTab.emit(5);
           });
         },
@@ -470,5 +476,7 @@ export class ZhFormTab4Component implements OnInit {
     }
   }
 
-  ngOnDestroy() {}
+  ngOnDestroy() {
+    this.hierarchy.warning = '';
+  }
 }

--- a/frontend/app/zh-forms/tabs/tab4/zh-form-tab4.component.ts
+++ b/frontend/app/zh-forms/tabs/tab4/zh-form-tab4.component.ts
@@ -475,6 +475,6 @@ export class ZhFormTab4Component implements OnInit {
   }
 
   ngOnDestroy() {
-    this.hierarchy.warning = '';
+    this.hierarchy.clear();
   }
 }

--- a/frontend/app/zh-forms/tabs/tab4/zh-form-tab4.component.ts
+++ b/frontend/app/zh-forms/tabs/tab4/zh-form-tab4.component.ts
@@ -459,9 +459,7 @@ export class ZhFormTab4Component implements OnInit {
             this._toastr.success('Vos données sont bien enregistrées', '', {
               positionClass: 'toast-top-right',
             });
-            if (this.currentZh.properties.main_id_rb) {
-              this.hierarchy.getHierarchy(this.currentZh.properties.id_zh);
-            }
+            this.hierarchy.getHierarchyFromZh(this.currentZh);
             this.nextTab.emit(5);
           });
         },

--- a/frontend/app/zh-forms/tabs/tab5/zh-form-tab5.component.ts
+++ b/frontend/app/zh-forms/tabs/tab5/zh-form-tab5.component.ts
@@ -1180,6 +1180,6 @@ export class ZhFormTab5Component implements OnInit {
   ngOnDestroy() {
     if (this.$_getTabChangeSub) this.$_getTabChangeSub.unsubscribe();
     if (this.$_currentZhSub) this.$_currentZhSub.unsubscribe();
-    this.hierarchy.warning = '';
+    this.hierarchy.clear();
   }
 }

--- a/frontend/app/zh-forms/tabs/tab5/zh-form-tab5.component.ts
+++ b/frontend/app/zh-forms/tabs/tab5/zh-form-tab5.component.ts
@@ -10,6 +10,7 @@ import { ModalService } from '../../../services/modal.service';
 import { TaxaFile } from './zh-form-tab5.models';
 import { ErrorTranslatorService } from '../../../services/error-translator.service';
 import { FilesService } from '../../../services/files.service';
+import { HierarchyService } from '../../../services/hierarchy.service';
 
 @Component({
   selector: 'zh-form-tab5',
@@ -192,7 +193,8 @@ export class ZhFormTab5Component implements OnInit {
     private _modalService: ModalService,
     private _error: ErrorTranslatorService,
     private _tabService: TabsService,
-    public _filesService: FilesService
+    public _filesService: FilesService,
+    public hierarchy: HierarchyService
   ) {}
 
   ngOnInit() {
@@ -1143,6 +1145,9 @@ export class ZhFormTab5Component implements OnInit {
             this._toastr.success('Vos données sont bien enregistrées', '', {
               positionClass: 'toast-top-right',
             });
+            if (this.currentZh.properties.main_id_rb) {
+              this.hierarchy.getHierarchy(this.currentZh.properties.id_zh);
+            }
             this.nextTab.emit(6);
           });
         },
@@ -1177,5 +1182,6 @@ export class ZhFormTab5Component implements OnInit {
   ngOnDestroy() {
     if (this.$_getTabChangeSub) this.$_getTabChangeSub.unsubscribe();
     if (this.$_currentZhSub) this.$_currentZhSub.unsubscribe();
+    this.hierarchy.warning = '';
   }
 }

--- a/frontend/app/zh-forms/tabs/tab5/zh-form-tab5.component.ts
+++ b/frontend/app/zh-forms/tabs/tab5/zh-form-tab5.component.ts
@@ -1145,9 +1145,7 @@ export class ZhFormTab5Component implements OnInit {
             this._toastr.success('Vos données sont bien enregistrées', '', {
               positionClass: 'toast-top-right',
             });
-            if (this.currentZh.properties.main_id_rb) {
-              this.hierarchy.getHierarchy(this.currentZh.properties.id_zh);
-            }
+            this.hierarchy.getHierarchyFromZh(this.currentZh);
             this.nextTab.emit(6);
           });
         },

--- a/frontend/app/zh-forms/tabs/tab6/zh-form-tab6.component.ts
+++ b/frontend/app/zh-forms/tabs/tab6/zh-form-tab6.component.ts
@@ -1021,6 +1021,6 @@ export class ZhFormTab6Component implements OnInit {
   ngOnDestroy() {
     if (this.$_getTabChangeSub) this.$_getTabChangeSub.unsubscribe();
     if (this.$_currentZhSub) this.$_currentZhSub.unsubscribe();
-    this.hierarchy.warning = '';
+    this.hierarchy.clear();
   }
 }

--- a/frontend/app/zh-forms/tabs/tab6/zh-form-tab6.component.ts
+++ b/frontend/app/zh-forms/tabs/tab6/zh-form-tab6.component.ts
@@ -992,9 +992,7 @@ export class ZhFormTab6Component implements OnInit {
             this._toastr.success('Vos données sont bien enregistrées', '', {
               positionClass: 'toast-top-right',
             });
-            if (this.currentZh.properties.main_id_rb) {
-              this.hierarchy.getHierarchy(this.currentZh.properties.id_zh);
-            }
+            this.hierarchy.getHierarchyFromZh(this.currentZh);
             this.nextTab.emit(7);
           });
         },

--- a/frontend/app/zh-forms/tabs/tab6/zh-form-tab6.component.ts
+++ b/frontend/app/zh-forms/tabs/tab6/zh-form-tab6.component.ts
@@ -14,6 +14,7 @@ import { DatepickerI18n, I18n } from '../../../services/datepicker-i18n.service'
 
 import { ZhDataService } from '../../../services/zh-data.service';
 import { ErrorTranslatorService } from '../../../services/error-translator.service';
+import { HierarchyService } from '../../../services/hierarchy.service';
 
 @Component({
   selector: 'zh-form-tab6',
@@ -135,7 +136,8 @@ export class ZhFormTab6Component implements OnInit {
     private _modalService: ModalService,
     private _error: ErrorTranslatorService,
     private _tabService: TabsService,
-    public config: ConfigService
+    public config: ConfigService,
+    public hierarchy: HierarchyService
   ) {}
 
   ngOnInit() {
@@ -990,6 +992,9 @@ export class ZhFormTab6Component implements OnInit {
             this._toastr.success('Vos données sont bien enregistrées', '', {
               positionClass: 'toast-top-right',
             });
+            if (this.currentZh.properties.main_id_rb) {
+              this.hierarchy.getHierarchy(this.currentZh.properties.id_zh);
+            }
             this.nextTab.emit(7);
           });
         },
@@ -1018,5 +1023,6 @@ export class ZhFormTab6Component implements OnInit {
   ngOnDestroy() {
     if (this.$_getTabChangeSub) this.$_getTabChangeSub.unsubscribe();
     if (this.$_currentZhSub) this.$_currentZhSub.unsubscribe();
+    this.hierarchy.warning = '';
   }
 }

--- a/frontend/app/zh-forms/tabs/tab7/zh-form-tab7.component.ts
+++ b/frontend/app/zh-forms/tabs/tab7/zh-form-tab7.component.ts
@@ -492,6 +492,6 @@ export class ZhFormTab7Component implements OnInit {
   ngOnDestroy() {
     if (this.$_getTabChangeSub) this.$_getTabChangeSub.unsubscribe();
     if (this.$_currentZhSub) this.$_currentZhSub.unsubscribe();
-    this.hierarchy.warning = '';
+    this.hierarchy.clear();
   }
 }

--- a/frontend/app/zh-forms/tabs/tab7/zh-form-tab7.component.ts
+++ b/frontend/app/zh-forms/tabs/tab7/zh-form-tab7.component.ts
@@ -6,6 +6,7 @@ import { Subscription } from 'rxjs';
 import { ZhDataService } from '../../../services/zh-data.service';
 import { TabsService } from '../../../services/tabs.service';
 import { ErrorTranslatorService } from '../../../services/error-translator.service';
+import { HierarchyService } from '../../../services/hierarchy.service';
 
 @Component({
   selector: 'zh-form-tab7',
@@ -145,7 +146,8 @@ export class ZhFormTab7Component implements OnInit {
     public ngbModal: NgbModal,
     private _dataService: ZhDataService,
     private _error: ErrorTranslatorService,
-    private _tabService: TabsService
+    private _tabService: TabsService,
+    public hierarchy: HierarchyService
   ) {}
 
   ngOnInit() {
@@ -464,6 +466,9 @@ export class ZhFormTab7Component implements OnInit {
             this._toastr.success('Vos données sont bien enregistrées', '', {
               positionClass: 'toast-top-right',
             });
+            if (this.currentZh.properties.main_id_rb) {
+              this.hierarchy.getHierarchy(this.currentZh.properties.id_zh);
+            }
             this.nextTab.emit(8);
           });
         },
@@ -489,5 +494,6 @@ export class ZhFormTab7Component implements OnInit {
   ngOnDestroy() {
     if (this.$_getTabChangeSub) this.$_getTabChangeSub.unsubscribe();
     if (this.$_currentZhSub) this.$_currentZhSub.unsubscribe();
+    this.hierarchy.warning = '';
   }
 }

--- a/frontend/app/zh-forms/tabs/tab7/zh-form-tab7.component.ts
+++ b/frontend/app/zh-forms/tabs/tab7/zh-form-tab7.component.ts
@@ -466,9 +466,7 @@ export class ZhFormTab7Component implements OnInit {
             this._toastr.success('Vos données sont bien enregistrées', '', {
               positionClass: 'toast-top-right',
             });
-            if (this.currentZh.properties.main_id_rb) {
-              this.hierarchy.getHierarchy(this.currentZh.properties.id_zh);
-            }
+            this.hierarchy.getHierarchyFromZh(this.currentZh);
             this.nextTab.emit(8);
           });
         },

--- a/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.ts
+++ b/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.ts
@@ -51,6 +51,6 @@ export class ZhFormTab9Component implements OnInit {
   ngOnDestroy() {
     if (this.$_getTabChangeSub) this.$_getTabChangeSub.unsubscribe();
     if (this.$_currentZhSub) this.$_currentZhSub.unsubscribe();
-    this.hierarchy.warning = '';
+    this.hierarchy.clear();
   }
 }


### PR DESCRIPTION
Les notes de hiérarchisation d'une zone humides sont générées lorsque l'utilisateur va sur l'onglet 9 (au niveau du backend correspond à la route /<int:id_zh>/hierarchy du blueprint). Les notes ne sont donc pas mises à jour dans 2 cas : 
- des champs utilisés pour le calcul de la hiérarchisation sont modifiés dans les onglets 1 à 7 par l'utilisateur, mais l'utilisateur ne va pas dans l'onglet 9. 
- des zones humides sont importées directement en base de données. La route backend de calcul des champs n'est donc pas appelée et les notes ne sont pas générées (il n'est pas possible de générer les notes directement en base de données)

2 solutions sont amenées par cette PR : 
- étant donné que le temps de calcul de la hiérarchisation est maintenant quasi instantané depuis l'intégration de la PR #101, le calcul de la hiérarchisation est exécuté à chaque fois que l'utilisateur clique sur "enregistrer" dans les onglets 1 à 7. Les notes de hiérarchisation sont donc toujours à jour. 
- un tâche celery exécutée quotidiennement met à jour les notes de toutes les zones humides. Permet de générer toutes les notes même en cas d'import de zones humides directement en base de données
 