### PR TITLE
fix/html_error_with_prettier

### DIFF
--- a/frontend/app/commonComponents/table/table.component.html
+++ b/frontend/app/commonComponents/table/table.component.html
@@ -13,6 +13,7 @@
   </thead>
   <tbody>
     <ng-container *ngIf="data && data.length > 0">
+      <!-- prettier-ignore -->
       <tr
         [ngStyle]="{
           background: item[color_col_name] == color_value ? '#EBFFE5' : 'rgba(67, 175, 0, 0.04)'


### PR DESCRIPTION
le check prettier rajoutait automatiquement une virgule à la fin de cette ligne html ce qui générait une erreur. Cet ajout permet d'ignorer le check prettier uniquement pour cette ligne