### PR TITLE
Modifier l'exemple de fichier de config qui créé une erreur

### DIFF
--- a/zones_humides_config.toml.example
+++ b/zones_humides_config.toml.example
@@ -112,9 +112,6 @@ fileformat_validated = true
 # téléversements
 file_path = "static"
 
-# Name of the source of species data (tab5)
-species_source_name = 'GeoNature'
-
 # -- Configuration relative à la génération de la fiche de synthèse pdf
 # Limite de superficie de la zone humide en dessous de laquelle
 # la couche définie par pdf_small_layer_number sera utilisée


### PR DESCRIPTION
Clé du fichier de config dupliquée :
`species_source_name`

Présente aux lignes suivantes : 
https://github.com/PnX-SI/gn_module_ZH/blob/f3094769046f579ccd4b377ae872e780b7d424b1/zones_humides_config.toml.example#L93

https://github.com/PnX-SI/gn_module_ZH/blob/f3094769046f579ccd4b377ae872e780b7d424b1/zones_humides_config.toml.example#L116
