### PR TITLE
fix 'cancelButton' in tab9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 **🐛 Corrections**
 
+- Ajout du boutton "quitter" sur l'onglet 9 (#114, by @juggler31)
+
 ## 1.4.0 - La Narse de Nouvialle (2025-03-27)
 
 Compatibilité avec GeoNature 2.15.0 minimum.

--- a/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.ts
+++ b/frontend/app/zh-forms/tabs/tab9/zh-form-tab9.component.ts
@@ -37,6 +37,7 @@ export class ZhFormTab9Component implements OnInit {
   getCurrentZh() {
     this.$_currentZhSub = this._dataService.currentZh.subscribe((zh: any) => {
       if (zh) {
+        this.currentZh = zh;
         if (zh.properties.main_rb_name != null) {
           this.main_rb_name = zh.properties.main_rb_name;
           this.hierarchy.getHierarchy(zh.id);


### PR DESCRIPTION
Avant: Le bouton ne s'affichait pas.

Maintenant: Le bouton "quitter" s'affiche et permet de quitter le mode édition.