### PR TITLE
add is_product_owner, maitre_ouvrage, echelle_saisie, ref_geo_saisie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,9 @@ venv.bak/
 
 # vscode
 .vscode/
+
+.idea
+cache
 # config module
 frontend/app/module.config.ts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 (à déterminer)
 
+**🚀 Nouveautés**
+
+- Ajout de 3 nouveau champs "product_owner", "input_scale", "input_ref_geo"(#52, by @juggler31)
+
 **🐛 Corrections**
 
 - Ajout du boutton "quitter" sur l'onglet 9 (#114, by @juggler31)

--- a/backend/gn_module_zh/blueprint.py
+++ b/backend/gn_module_zh/blueprint.py
@@ -28,7 +28,7 @@ from geonature.core.gn_permissions.tools import get_scopes_by_action
 from ref_geo.models import BibAreasTypes, LAreas, LiMunicipalities
 from geonature.utils.config import config
 from geonature.utils.env import DB, ROOT_DIR, BACKEND_DIR
-from pypnnomenclature.models import TNomenclatures
+from pypnnomenclature.models import TNomenclatures, BibNomenclaturesTypes
 from pypnusershub.db.models import Organisme, User
 from sqlalchemy import desc, func, text, select, update, delete
 from sqlalchemy.orm import aliased
@@ -375,6 +375,8 @@ def get_pbf_complete():
                tz.menaces,
                tz.diagnostic_bio,
                tz.diagnostic_hydro,
+               tz.product_owner,
+               tz.input_scale,
                Json_build_object('criteres_delim', tz.criteres_delim,
                          'communes',
                          tz.communes,
@@ -435,24 +437,16 @@ def get_geometries():
         DB.session.close()
 
 
-@blueprint.route("/references/autocomplete", methods=["GET"])
+@blueprint.route("/product_owners", methods=["GET"])
 @permissions.check_cruved_scope("R", module_code="ZONES_HUMIDES")
 @json_resp
-def get_ref_autocomplete():
+def get_product_owners():
     try:
-        params = request.args
-        search_title = params.get("search_title")
-        # search_title = 'MCD'
-        q = select(TReferences, func.similarity(TReferences.title, search_title).label("idx_trgm"))
-
-        search_title = search_title.replace(" ", "%")
-        q = q.where(TReferences.title.ilike("%" + search_title + "%")).order_by(desc("idx_trgm"))
-
+        q = select(BibOrganismes).where(BibOrganismes.is_product_owner == True)
         limit = request.args.get("limit", 20)
-
         data = DB.session.execute(q.limit(limit)).all()
         if data:
-            return [d[0].as_dict() for d in data]
+            return [d[0].as_dict() if hasattr(d[0], "as_dict") else d[0] for d in data]
         else:
             return "No Result", 404
     except Exception as e:
@@ -460,7 +454,100 @@ def get_ref_autocomplete():
             raise ZHApiError(message=str(e.message), details=str(e.details))
         exc_type, value, tb = sys.exc_info()
         raise ZHApiError(
-            message="get_ref_autocomplete_error",
+            message="get_product_owners",
+            details=str(exc_type) + ": " + str(e.with_traceback(tb)),
+        )
+    finally:
+        DB.session.close()
+
+
+@blueprint.route("/input_ref_geo", methods=["GET"])
+@permissions.check_cruved_scope("R", module_code="ZONES_HUMIDES")
+@json_resp
+def get_input_ref_geo():
+    try:
+        id_nommenclature_type = DB.session.execute(
+            select(BibNomenclaturesTypes.id_type).where(
+                BibNomenclaturesTypes.mnemonique.like("INPUT_REF_GEO")
+            )
+        ).scalar_one()
+        q = select(TNomenclatures.mnemonique).where(TNomenclatures.id_type == id_nommenclature_type)
+        data = DB.session.execute(q).all()
+        if data:
+            return [d[0].as_dict() if hasattr(d[0], "as_dict") else d[0] for d in data]
+        else:
+            return "No Result", 404
+    except Exception as e:
+        if e.__class__.__name__ == "ZHApiError":
+            raise ZHApiError(message=str(e.message), details=str(e.details))
+        exc_type, value, tb = sys.exc_info()
+        raise ZHApiError(
+            message="get_product_owners",
+            details=str(exc_type) + ": " + str(e.with_traceback(tb)),
+        )
+    finally:
+        DB.session.close()
+
+
+@blueprint.route("/input_scale", methods=["GET"])
+@permissions.check_cruved_scope("R", module_code="ZONES_HUMIDES")
+@json_resp
+def get_input_scale():
+    try:
+        id_nommenclature_type = DB.session.execute(
+            select(BibNomenclaturesTypes.id_type).where(
+                BibNomenclaturesTypes.mnemonique.like("INPUT_SCALE")
+            )
+        ).scalar_one()
+        q = select(TNomenclatures.mnemonique).where(TNomenclatures.id_type == id_nommenclature_type)
+        data = DB.session.execute(q).all()
+        if data:
+            return [d[0].as_dict() if hasattr(d[0], "as_dict") else d[0] for d in data]
+        else:
+            return "No Result", 404
+    except Exception as e:
+        if e.__class__.__name__ == "ZHApiError":
+            raise ZHApiError(message=str(e.message), details=str(e.details))
+        exc_type, value, tb = sys.exc_info()
+        raise ZHApiError(
+            message="get_product_owners",
+            details=str(exc_type) + ": " + str(e.with_traceback(tb)),
+        )
+    finally:
+        DB.session.close()
+
+
+@blueprint.route("/autocomplete/<string:field>", methods=["GET"])
+@permissions.check_cruved_scope("R", module_code="ZONES_HUMIDES")
+@json_resp
+def get_autocomplete(field):
+    try:
+        params = request.args
+        if field == "references":
+            search_title = params.get("search_title")
+            # search_title = 'MCD'
+            q = select(
+                TReferences, func.similarity(TReferences.title, search_title).label("idx_trgm")
+            )
+
+            search_title = search_title.replace(" ", "%")
+            q = q.where(TReferences.title.ilike("%" + search_title + "%")).order_by(
+                desc("idx_trgm")
+            )
+        else:
+            raise NotFound(f"Field {field} not found for autocomplete")
+        limit = request.args.get("limit", 20)
+        data = DB.session.execute(q.limit(limit)).all()
+        if data:
+            return [d[0].as_dict() if hasattr(d[0], "as_dict") else d[0] for d in data]
+        else:
+            return "No Result", 404
+    except Exception as e:
+        if e.__class__.__name__ == "ZHApiError":
+            raise ZHApiError(message=str(e.message), details=str(e.details))
+        exc_type, value, tb = sys.exc_info()
+        raise ZHApiError(
+            message=f"get_autocomplete_error on field: {field}",
             details=str(exc_type) + ": " + str(e.with_traceback(tb)),
         )
     finally:
@@ -643,7 +730,6 @@ def get_tab_data(id_tab):
             raise BadRequest(
                 "Géométrie manquante",
             )
-
         # POST / PATCH
         if "id_zh" not in form_data.keys():
             # set geometry from coordinates

--- a/backend/gn_module_zh/conf_schema_toml.py
+++ b/backend/gn_module_zh/conf_schema_toml.py
@@ -26,6 +26,7 @@ available_maplist_column = [
     {"prop": "code", "name": "Code"},
     {"prop": "sdage", "name": "Typologie SDAGE", "sortable": True},
     {"prop": "bassin_versant", "name": "Bassin versant", "sortable": True},
+    {"prop": "input_scale", "name": "Échelle de saisie"},
     {"prop": "delims", "name": "Critères délimitation (de la zh)", "sortable": True},
     {"prop": "create_date", "name": "Date de création"},
     {"prop": "author", "name": "Auteur"},

--- a/backend/gn_module_zh/migrations/6f343b68d85f_add_maitre_ouvrage_echelle_saisie_ref_.py
+++ b/backend/gn_module_zh/migrations/6f343b68d85f_add_maitre_ouvrage_echelle_saisie_ref_.py
@@ -1,0 +1,379 @@
+"""Ajout des champs product_owner, input_scale, input_ref_geo à t_zh et ajout du champ is_product_owner dans bib_organismes
+
+Revision ID: 6f343b68d85f
+Revises: ea0eefb3744a
+Create Date: 2025-07-28 15:44:17.558807
+
+"""
+
+from alembic import op
+from sqlalchemy import Column, Integer, UnicodeText, Boolean
+
+
+# revision identifiers, used by Alembic.
+revision = "6f343b68d85f"
+down_revision = "ea0eefb3744a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        schema="pr_zh",
+        table_name="t_zh",
+        column=Column(
+            "product_owner",
+            UnicodeText,
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        schema="pr_zh",
+        table_name="t_zh",
+        column=Column(
+            "input_scale",
+            Integer,
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        schema="pr_zh",
+        table_name="t_zh",
+        column=Column(
+            "input_ref_geo",
+            UnicodeText,
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        schema="pr_zh",
+        table_name="bib_organismes",
+        column=Column(
+            "is_product_owner",
+            Boolean,
+            default=True,
+            nullable=True,
+        ),
+    )
+    op.execute("UPDATE pr_zh.bib_organismes SET is_product_owner = true")
+    op.alter_column(
+        schema="pr_zh", table_name="bib_organismes", column_name="is_product_owner", nullable=False
+    )
+
+    # Add nommenclature type
+    op.execute(
+        """
+        INSERT INTO
+            ref_nomenclatures.bib_nomenclatures_types
+        (
+            mnemonique,
+            label_default,
+            definition_default,
+            label_fr,
+            definition_fr,
+            source,
+            statut
+        )
+        VALUES
+            (
+                'INPUT_SCALE',
+                'Echelle de saisie',
+                'Echelle de saisie',
+                'Echelle de saisie',
+                'Echelle de saisie',
+                'ZONES_HUMIDES',
+                'Non validé'
+            ),
+            (
+                'INPUT_REF_GEO',
+                'Référentiel de saisie',
+                'Référentiel de saisie',
+                'Référentiel de saisie',
+                'Référentiel de saisie',
+                'ZONES_HUMIDES',
+                'Non validé'
+            )
+        """
+    )
+
+    # Add nommenclature
+    op.execute(
+        """
+        INSERT INTO
+            ref_nomenclatures.t_nomenclatures
+        (
+            id_type,
+            cd_nomenclature,
+            mnemonique,
+            label_default,
+            definition_default,
+            label_fr,
+            definition_fr,
+            source,
+            statut,
+            active
+        )
+        VALUES
+            (
+                (SELECT id_type FROM ref_nomenclatures.bib_nomenclatures_types WHERE mnemonique = 'INPUT_SCALE'),
+                '2500',
+                '2500',
+                'Echelle de saisie 1/2500ème',
+                'Echelle de saisie 1/2500ème',
+                'Echelle de saisie 1/2500ème',
+                'Echelle de saisie 1/2500ème',
+                'ZONES_HUMIDES',
+                'Non validé',
+                true
+            ),
+            (
+                (SELECT id_type FROM ref_nomenclatures.bib_nomenclatures_types WHERE mnemonique = 'INPUT_SCALE'),
+                '5000',
+                '5000',
+                'Echelle de saisie 1/5000ème',
+                'Echelle de saisie 1/5000ème',
+                'Echelle de saisie 1/5000ème',
+                'Echelle de saisie 1/5000ème',
+                'ZONES_HUMIDES',
+                'Non validé',
+                true
+            ),
+            (
+                (SELECT id_type FROM ref_nomenclatures.bib_nomenclatures_types WHERE mnemonique = 'INPUT_SCALE'),
+                '10000',
+                '10000',
+                'Echelle de saisie 1/10000ème',
+                'Echelle de saisie 1/10000ème',
+                'Echelle de saisie 1/10000ème',
+                'Echelle de saisie 1/10000ème',
+                'ZONES_HUMIDES',
+                'Non validé',
+                true
+            ),
+            (
+                (SELECT id_type FROM ref_nomenclatures.bib_nomenclatures_types WHERE mnemonique = 'INPUT_SCALE'),
+                '25000',
+                '25000',
+                'Echelle de saisie 1/25000ème',
+                'Echelle de saisie 1/25000ème',
+                'Echelle de saisie 1/25000ème',
+                'Echelle de saisie 1/25000ème',
+                'ZONES_HUMIDES',
+                'Non validé',
+                true
+            )
+
+        """
+    )
+
+    op.execute(
+        """
+        INSERT INTO
+            ref_nomenclatures.t_nomenclatures
+        (
+            id_type,
+            cd_nomenclature,
+            mnemonique,
+            label_default,
+            definition_default,
+            label_fr,
+            definition_fr,
+            source,
+            statut,
+            active
+        )
+        VALUES
+            (
+                (SELECT id_type FROM ref_nomenclatures.bib_nomenclatures_types WHERE mnemonique = 'INPUT_REF_GEO'),
+                'BD ORTHO®',
+                'BD ORTHO®',
+                'BD ORTHO®',
+                'BD ORTHO®',
+                'BD ORTHO®',
+                'BD ORTHO®',
+                'ZONES_HUMIDES',
+                'Non validé',
+                true
+            ),
+            (
+                (SELECT id_type FROM ref_nomenclatures.bib_nomenclatures_types WHERE mnemonique = 'INPUT_REF_GEO'),
+                'SCAN 25®',
+                'SCAN 25®',
+                'SCAN 25®',
+                'SCAN 25®',
+                'SCAN 25®',
+                'SCAN 25®',
+                'ZONES_HUMIDES',
+                'Non validé',
+                true
+            ),
+            (
+                (SELECT id_type FROM ref_nomenclatures.bib_nomenclatures_types WHERE mnemonique = 'INPUT_REF_GEO'),
+                'SCAN 100®',
+                'SCAN 100®',
+                'SCAN 100®',
+                'SCAN 100®',
+                'SCAN 100®',
+                'SCAN 100®',
+                'ZONES_HUMIDES',
+                'Non validé',
+                true
+            ),
+            (
+                (SELECT id_type FROM ref_nomenclatures.bib_nomenclatures_types WHERE mnemonique = 'INPUT_REF_GEO'),
+                'OpenStreetMap',
+                'OpenStreetMap',
+                'OpenStreetMap',
+                'OpenStreetMap',
+                'OpenStreetMap',
+                'OpenStreetMap',
+                'ZONES_HUMIDES',
+                'Non validé',
+                true
+            ),
+            (
+                (SELECT id_type FROM ref_nomenclatures.bib_nomenclatures_types WHERE mnemonique = 'INPUT_REF_GEO'),
+                'OpenTopoMap',
+                'OpenTopoMap',
+                'OpenTopoMap',
+                'OpenTopoMap',
+                'OpenTopoMap',
+                'OpenTopoMap',
+                'ZONES_HUMIDES',
+                'Non validé',
+                true
+            )
+
+        """
+    )
+
+    # Update atlas_app view
+    op.execute("DROP VIEW IF EXISTS pr_zh.atlas_app")
+    op.execute(
+        """
+        CREATE OR REPLACE VIEW pr_zh.atlas_app
+            AS SELECT tzh.id_zh AS id,
+                      tzh.main_name AS nom,
+                      ( SELECT pr_zh.slugify(tzh.main_name::text) AS slugify) AS slug,
+                      tzh.code,
+                      tzh.create_date AS date,
+                tzh.geom AS polygon_4326,
+                tzh.product_owner,
+                tzh.input_scale,
+                ( SELECT st_area(st_transform(st_setsrid(tzh.geom, 4326), 2154)) AS st_area) AS superficie,
+                bo.nom_organisme AS operateur,
+                sdage.cd_nomenclature AS type_code,
+                sdage.mnemonique AS type,
+                thread.mnemonique AS menaces,
+                diag_bio.mnemonique AS diagnostic_bio,
+                diag_hydro.mnemonique AS diagnostic_hydro,
+                ( SELECT array_agg(DISTINCT tn.mnemonique) AS array_agg) AS criteres_delim,
+                ( SELECT array_agg(DISTINCT la.area_name) AS array_agg) AS communes,
+                ( SELECT array_agg(DISTINCT trb.name) AS array_agg) AS bassin_versant,
+                ( SELECT COALESCE(json_agg(t.*), '[]'::json) AS "coalesce"
+                    FROM ( SELECT t_medias.title_fr AS label,
+                                t_medias.media_path AS url
+                            FROM gn_commons.t_medias
+                            WHERE t_medias.uuid_attached_row = tzh.zh_uuid) t) AS images
+               FROM pr_zh.t_zh tzh
+                                  LEFT JOIN pr_zh.cor_lim_list cll ON tzh.id_lim_list = cll.id_lim_list
+                                  LEFT JOIN ref_nomenclatures.t_nomenclatures tn ON cll.id_lim = tn.id_nomenclature
+                                  LEFT JOIN pr_zh.cor_zh_area cza ON tzh.id_zh = cza.id_zh
+                                  LEFT JOIN ref_geo.l_areas la ON cza.id_area = la.id_area
+                                  LEFT JOIN pr_zh.cor_zh_rb czr ON tzh.id_zh = czr.id_zh
+                                  LEFT JOIN pr_zh.t_river_basin trb ON czr.id_rb = trb.id_rb
+                                  LEFT JOIN gn_commons.t_medias med ON med.uuid_attached_row = tzh.zh_uuid
+                                  LEFT JOIN utilisateurs.t_roles tr ON tr.id_role = tzh.create_author
+                                  LEFT JOIN utilisateurs.bib_organismes bo ON bo.id_organisme = tr.id_organisme
+                                  LEFT JOIN ref_nomenclatures.t_nomenclatures sdage ON sdage.id_nomenclature = tzh.id_sdage
+                                  LEFT JOIN ref_nomenclatures.t_nomenclatures thread ON thread.id_nomenclature = tzh.id_thread
+                                  LEFT JOIN ref_nomenclatures.t_nomenclatures diag_bio ON diag_bio.id_nomenclature = tzh.id_diag_bio
+                                  LEFT JOIN ref_nomenclatures.t_nomenclatures diag_hydro ON diag_hydro.id_nomenclature = tzh.id_diag_hydro
+               WHERE cza.cover IS NOT NULL
+               GROUP BY tzh.id_zh, bo.nom_organisme, sdage.cd_nomenclature, sdage.mnemonique, thread.mnemonique, diag_bio.mnemonique, diag_hydro.mnemonique
+               ORDER BY tzh.id_zh;
+        """
+    )
+
+
+def downgrade():
+
+    # Rollback atlas_app view
+    op.execute("DROP VIEW IF EXISTS pr_zh.atlas_app")
+    op.execute(
+        """
+        CREATE OR REPLACE VIEW pr_zh.atlas_app
+            AS SELECT tzh.id_zh AS id,
+                      tzh.main_name AS nom,
+                      ( SELECT pr_zh.slugify(tzh.main_name::text) AS slugify) AS slug,
+                      tzh.code,
+                      tzh.create_date AS date,
+                tzh.geom AS polygon_4326,
+                ( SELECT st_area(st_transform(st_setsrid(tzh.geom, 4326), 2154)) AS st_area) AS superficie,
+                bo.nom_organisme AS operateur,
+                sdage.cd_nomenclature AS type_code,
+                sdage.mnemonique AS type,
+                thread.mnemonique AS menaces,
+                diag_bio.mnemonique AS diagnostic_bio,
+                diag_hydro.mnemonique AS diagnostic_hydro,
+                ( SELECT array_agg(DISTINCT tn.mnemonique) AS array_agg) AS criteres_delim,
+                ( SELECT array_agg(DISTINCT la.area_name) AS array_agg) AS communes,
+                ( SELECT array_agg(DISTINCT trb.name) AS array_agg) AS bassin_versant,
+                ( SELECT COALESCE(json_agg(t.*), '[]'::json) AS "coalesce"
+                    FROM ( SELECT t_medias.title_fr AS label,
+                                t_medias.media_path AS url
+                            FROM gn_commons.t_medias
+                            WHERE t_medias.uuid_attached_row = tzh.zh_uuid) t) AS images
+               FROM pr_zh.t_zh tzh
+                                  LEFT JOIN pr_zh.cor_lim_list cll ON tzh.id_lim_list = cll.id_lim_list
+                                  LEFT JOIN ref_nomenclatures.t_nomenclatures tn ON cll.id_lim = tn.id_nomenclature
+                                  LEFT JOIN pr_zh.cor_zh_area cza ON tzh.id_zh = cza.id_zh
+                                  LEFT JOIN ref_geo.l_areas la ON cza.id_area = la.id_area
+                                  LEFT JOIN pr_zh.cor_zh_rb czr ON tzh.id_zh = czr.id_zh
+                                  LEFT JOIN pr_zh.t_river_basin trb ON czr.id_rb = trb.id_rb
+                                  LEFT JOIN gn_commons.t_medias med ON med.uuid_attached_row = tzh.zh_uuid
+                                  LEFT JOIN utilisateurs.t_roles tr ON tr.id_role = tzh.create_author
+                                  LEFT JOIN utilisateurs.bib_organismes bo ON bo.id_organisme = tr.id_organisme
+                                  LEFT JOIN ref_nomenclatures.t_nomenclatures sdage ON sdage.id_nomenclature = tzh.id_sdage
+                                  LEFT JOIN ref_nomenclatures.t_nomenclatures thread ON thread.id_nomenclature = tzh.id_thread
+                                  LEFT JOIN ref_nomenclatures.t_nomenclatures diag_bio ON diag_bio.id_nomenclature = tzh.id_diag_bio
+                                  LEFT JOIN ref_nomenclatures.t_nomenclatures diag_hydro ON diag_hydro.id_nomenclature = tzh.id_diag_hydro
+               WHERE cza.cover IS NOT NULL
+               GROUP BY tzh.id_zh, bo.nom_organisme, sdage.cd_nomenclature, sdage.mnemonique, thread.mnemonique, diag_bio.mnemonique, diag_hydro.mnemonique
+               ORDER BY tzh.id_zh;
+        """
+    )
+
+    op.execute(
+        """
+        DELETE FROM ref_nomenclatures.t_nomenclatures
+        WHERE mnemonique IN ('2500', '5000', '10000', '25000', 'BD ORTHO®', 'SCAN 25®', 'SCAN 100®', 'OpenStreetMap', 'OpenTopoMap');
+        """
+    )
+    op.execute(
+        """
+        DELETE FROM ref_nomenclatures.bib_nomenclatures_types
+        WHERE mnemonique IN ('INPUT_REF_GEO', 'INPUT_SCALE');
+        """
+    )
+
+    op.drop_column(
+        schema="pr_zh",
+        table_name="t_zh",
+        column_name="product_owner",
+    )
+    op.drop_column(
+        schema="pr_zh",
+        table_name="t_zh",
+        column_name="input_scale",
+    )
+    op.drop_column(
+        schema="pr_zh",
+        table_name="t_zh",
+        column_name="input_ref_geo",
+    )
+    op.drop_column(
+        schema="pr_zh",
+        table_name="bib_organismes",
+        column_name="is_product_owner",
+    )

--- a/backend/gn_module_zh/model/cards.py
+++ b/backend/gn_module_zh/model/cards.py
@@ -76,7 +76,8 @@ class Utils(ZH):
 
 
 class Limits:
-    def __init__(self):
+    def __init__(self, zh_props):
+        self.zh_props = zh_props
         self.area_limits = Criteria
         self.function_limits = Criteria
 
@@ -100,7 +101,17 @@ class Limits:
         return {
             "delimitation_zone": self.area_limits.__str__(),
             "delimitation_fonctions": self.function_limits.__str__(),
+            "input_scale": self.__get_input_scale(),
+            "input_ref_geo": self.__get_input_ref_geo(),
         }
+
+    def __get_input_scale(self):
+        input_scale = self.zh_props["input_scale"]
+        return input_scale if input_scale is not None else ""
+
+    def __get_input_ref_geo(self):
+        input_ref_geo = self.zh_props["input_ref_geo"]
+        return input_ref_geo if input_ref_geo is not None else ""
 
 
 class Criteria:
@@ -186,10 +197,12 @@ class Author:
         self.create_author = self.__get_author()
         self.edit_author = self.__get_author(type="coauthors")
         self.organism = self.__get_organism()
+        self.product_owner = self.__get_product_owner()
         self.coorganism = self.__get_organism(type="coauthors")
 
     def __str__(self):
         return {
+            "product_owner": self.product_owner,
             "auteur": self.create_author,
             "auteur_modif": self.edit_author,
             "date": self.create_date,
@@ -210,6 +223,10 @@ class Author:
     def __get_organism(self, type="authors"):
         author = getattr(self.zh, type)
         return author.organisme.nom_organisme if author.organisme is not None else ""
+
+    def __get_product_owner(self):
+        product_owner = getattr(self.zh, "product_owner")
+        return product_owner if product_owner is not None else ""
 
 
 class Municipalities:
@@ -1030,7 +1047,7 @@ class Card(ZH):
         self.properties = self.get_properties()
         self.eval = self.get_eval()
         self.info = Info()
-        self.limits = Limits()
+        self.limits = Limits(self.properties)
         self.functioning = Functioning()
         self.functions = Functions()
         self.description = Description()

--- a/backend/gn_module_zh/model/zh_schema.py
+++ b/backend/gn_module_zh/model/zh_schema.py
@@ -142,6 +142,7 @@ class BibOrganismes(DB.Model):
     name = DB.Column(DB.Unicode(length=6), nullable=False)
     abbrevation = DB.Column(DB.Unicode, nullable=False)
     is_op_org = DB.Column(DB.Boolean, default=False, nullable=False)
+    is_product_owner = DB.Column(DB.Boolean, default=True, nullable=False)
 
     @staticmethod
     def get_abbrevation(id_org):
@@ -248,6 +249,9 @@ class TZH(ZhModel):
     main_pict_id = DB.Column(DB.Integer)
     area = DB.Column(DB.Float)
     main_id_rb = DB.Column(DB.Integer, nullable=True)
+    product_owner = DB.Column(DB.Unicode, nullable=True)
+    input_scale = DB.Column(DB.Integer, nullable=True)
+    input_ref_geo = DB.Column(DB.Unicode, nullable=True)
 
     sdage = DB.relationship(
         TNomenclatures,

--- a/backend/gn_module_zh/templates/delimitation.html
+++ b/backend/gn_module_zh/templates/delimitation.html
@@ -1,5 +1,18 @@
 <div>
   <section class="content col">
+    <h5 class="subtitle">Échelle et référentiel de saisie</h5>
+      <span class="small-title"><b>Échelle de saisie : </b>
+          {% if data['delimitation']['input_scale'] %}
+              1/{{ data['delimitation']['input_scale']}}ème
+          {% else %}
+              Non identifié
+          {% endif %}
+      </span>
+      <span class="small-title"><b>Référentiel de saisie : </b>
+          {{ data['delimitation']['input_ref_geo'] or 'Non identifié' }}
+      </span>
+  </section>
+  <section class="content col">
     <h5 class="subtitle">Critères de délimitation de la zone humide</h5>
       <span class="small-title"><b>Critères utilisés :</b></span><br>
       {% for critere in data['delimitation']['delimitation_zone']['critere'] %}

--- a/backend/gn_module_zh/templates/renseignements.html
+++ b/backend/gn_module_zh/templates/renseignements.html
@@ -56,6 +56,13 @@
 
 <div class="separator"></div>
 
+  <div class="col" id="col-r">
+    <div class="fieldset" id="fieldset-r">
+      <label>Maitre d'ouvrage de l'inventaire</label>
+      <span>{{ data['renseignements']['auteur']['product_owner'] or 'Non identifié' }}</span>
+    </div>
+  </div>
+
 <div class="row">
   <div class="col" id="col-r">
     <div class="fieldset" id="fieldset-r">

--- a/frontend/.nvmrc
+++ b/frontend/.nvmrc
@@ -1,1 +1,1 @@
-lts/gallium
+lts/iron

--- a/frontend/app/module.config.ts
+++ b/frontend/app/module.config.ts
@@ -23,6 +23,10 @@ export const ModuleConfig = {
       sortable: true,
     },
     {
+      name: 'Échelle de saisie',
+      prop: 'echelle_saisie',
+    },
+    {
       name: 'Crit\u00e8res d\u00e9limitation (de la zh)',
       prop: 'delims',
       sortable: true,
@@ -70,6 +74,10 @@ export const ModuleConfig = {
       name: 'Bassin versant',
       prop: 'bassin_versant',
       sortable: true,
+    },
+    {
+      name: 'Échelle de saisie',
+      prop: 'echelle_saisie',
     },
   ],
   file_path: 'static',

--- a/frontend/app/services/zh-data.service.ts
+++ b/frontend/app/services/zh-data.service.ts
@@ -47,8 +47,20 @@ export class ZhDataService {
 
   autocompletBib(search_title: string) {
     return this._api.get<any>(
-      `${this.config.API_ENDPOINT}/zones_humides/references/autocomplete?search_title=${search_title}`
+      `${this.config.API_ENDPOINT}/zones_humides/autocomplete/references?search_title=${search_title}`
     );
+  }
+
+  getProductOwners() {
+    return this._api.get<any>(`${this.config.API_ENDPOINT}/zones_humides/product_owners`);
+  }
+
+  getRefGeoSaisie() {
+    return this._api.get<any>(`${this.config.API_ENDPOINT}/zones_humides/input_ref_geo`);
+  }
+
+  getEchelleSaisie() {
+    return this._api.get<any>(`${this.config.API_ENDPOINT}/zones_humides/input_scale`);
   }
 
   checkRefGeo() {

--- a/frontend/app/zh-details/delimitation/delimitation.component.html
+++ b/frontend/app/zh-details/delimitation/delimitation.component.html
@@ -1,5 +1,30 @@
 <div>
   <div class="row my-3">
+    <div class="col-12 h-100">
+      <fieldset>
+        <legend>
+          <h5 class="section-title">Échelle et référentiel de saisie</h5>
+        </legend>
+        <div class="row">
+          <div class="col-12 col-xl-6">
+            <zh-label label="Échelle de saisie :">
+              <div *ngIf="data?.input_scale; then thenEchelleSaisie; else elseEchelleSaisie"></div>
+              <ng-template #thenEchelleSaisie>1/{{ data.input_scale }}ème</ng-template>
+              <ng-template #elseEchelleSaisie>Non identifié</ng-template>
+            </zh-label>
+          </div>
+          <div class="col-12 col-xl-6">
+            <zh-label label="Référentiel de saisie :">
+              <div *ngIf="data?.input_ref_geo; then thenRefGeoSaisie; else elseRefGeoSaisie"></div>
+              <ng-template #thenRefGeoSaisie>{{ data.input_ref_geo }}</ng-template>
+              <ng-template #elseRefGeoSaisie>Non identifié</ng-template>
+            </zh-label>
+          </div>
+        </div>
+        <p class="label"><b></b></p>
+      </fieldset>
+    </div>
+
     <div class="col-12 col-xl-6 col-lg-6 col-md-6">
       <fieldset>
         <legend>

--- a/frontend/app/zh-details/models/delimitation.model.ts
+++ b/frontend/app/zh-details/models/delimitation.model.ts
@@ -1,6 +1,8 @@
 export interface DelimitationModel {
   delimitation_zone: Criteres;
   delimitation_fonctions: Criteres;
+  input_scale: null | string;
+  input_ref_geo: null | string;
   basin: any;
 }
 

--- a/frontend/app/zh-details/models/renseignements.model.ts
+++ b/frontend/app/zh-details/models/renseignements.model.ts
@@ -26,6 +26,7 @@ interface Identification {
 }
 
 interface Auteur {
+  product_owner: string;
   auteur: string;
   organism: string;
   coorganism: string;

--- a/frontend/app/zh-details/renseignements/renseignements.component.html
+++ b/frontend/app/zh-details/renseignements/renseignements.component.html
@@ -32,6 +32,15 @@
         </legend>
         <div class="row">
           <div class="col-6">
+            <zh-label label="Maitre d'ouvrage :">
+              <div
+                *ngIf="data.auteur?.product_owner; then thenproduct_owner; else elseproduct_owner"
+              ></div>
+              <ng-template #thenproduct_owner>{{ data.auteur.product_owner }}</ng-template>
+              <ng-template #elseproduct_owner>Non identifié</ng-template>
+            </zh-label>
+          </div>
+          <div class="col-6">
             <zh-label label="Auteur de la fiche :">
               <span>{{ data.auteur?.auteur }}</span>
             </zh-label>

--- a/frontend/app/zh-forms/tabs/tab1/zh-form-tab1.component.html
+++ b/frontend/app/zh-forms/tabs/tab1/zh-form-tab1.component.html
@@ -63,6 +63,30 @@
     </fieldset>
     <fieldset>
       <legend>
+        <h5 class="section-title">Maitre d'ouvrage de l'inventaire</h5>
+      </legend>
+      <small>Maitre d'ouvrage</small>
+      <div class="form-row">
+        <div class="form-group col-md-6">
+          <zh-multiselect
+            [values]="listProductOwner"
+            keyLabel="name"
+            [parentFormControl]="formProductOwner.controls.productOwner"
+            (onOpen)="allListProductOwner()"
+            [multiple]="false"
+          />
+        </div>
+      </div>
+      <span
+        class="form-row"
+        class="bib-hint"
+      >
+        Si vous ne trouvez pas le maitre d'ouvrage que vous cherchez, veuillez contacter
+        l'administrateur
+      </span>
+    </fieldset>
+    <fieldset>
+      <legend>
         <h5 class="section-title">Principales références bibliographiques</h5>
       </legend>
       <div class="form-row">

--- a/frontend/app/zh-forms/tabs/tab1/zh-form-tab1.component.ts
+++ b/frontend/app/zh-forms/tabs/tab1/zh-form-tab1.component.ts
@@ -20,6 +20,10 @@ export class ZhFormTab1Component implements OnInit {
   @Output() canChangeTab = new EventEmitter<boolean>();
   @Output() nextTab = new EventEmitter<number>();
   public generalInfoForm: FormGroup;
+  public formProductOwner: FormGroup;
+  public listProductOwner: {
+    name: string;
+  }[] = [];
   public bibForm: FormGroup;
   public siteSpaceList: any[];
   public hasSiteSpace = false;
@@ -70,6 +74,9 @@ export class ZhFormTab1Component implements OnInit {
     this.$_currentZhSub = this._dataService.currentZh.subscribe((zh: any) => {
       if (zh) {
         this.currentZh = zh;
+        this.formProductOwner = this.fb.group({
+          productOwner: { name: this.currentZh.properties.product_owner },
+        });
         this.listBib = [...this.currentZh.properties.id_references];
         this.generalInfoForm.patchValue({
           main_name: this.currentZh.properties.main_name,
@@ -94,6 +101,9 @@ export class ZhFormTab1Component implements OnInit {
       is_id_site_space: null,
     });
     this.onFormValueChanges();
+    this.formProductOwner = this.fb.group({
+      productOwner: null,
+    });
   }
 
   onFormValueChanges(): void {
@@ -140,6 +150,7 @@ export class ZhFormTab1Component implements OnInit {
       id_zh: Number(this.currentZh.properties.id_zh),
       id_site_space: formValues.id_site_space,
       is_id_site_space: formValues.is_id_site_space,
+      product_owner: this.formProductOwner.value.productOwner.name,
       id_references: [],
     };
 
@@ -175,6 +186,12 @@ export class ZhFormTab1Component implements OnInit {
       );
     }
   }
+
+  allListProductOwner = () => {
+    this._dataService.getProductOwners().subscribe((res) => {
+      this.listProductOwner = res;
+    });
+  };
 
   search = (text$: Observable<string>) =>
     text$.pipe(

--- a/frontend/app/zh-forms/tabs/tab2/zh-form-tab2.component.html
+++ b/frontend/app/zh-forms/tabs/tab2/zh-form-tab2.component.html
@@ -3,6 +3,37 @@
     <h2 class="tabsTitle">Délimitation de la zone humide et de l'espace de fonctionnalité</h2>
     <fieldset>
       <legend>
+        <h5 class="section-title">Échelle et référentiel de saisie</h5>
+      </legend>
+      <div class="form-row">
+        <div class="form-group col-md-12">
+          <div class="form-row">
+            <div class="form-group col-md-6">
+              <small>Échelle de saisie</small>
+              <zh-multiselect
+                [values]="listEchelleSaisie"
+                keyLabel="name"
+                [parentFormControl]="formTab2.controls.echelleSaisie"
+                (onOpen)="allListEchelleSaisie()"
+                [multiple]="false"
+              />
+            </div>
+            <div class="form-group col-md-6">
+              <small>Référentiel de saisie</small>
+              <zh-multiselect
+                [values]="listRefGeoSaisie"
+                keyLabel="name"
+                [parentFormControl]="formTab2.controls.refGeoSaisie"
+                (onOpen)="allListRefGeoSaisie()"
+                [multiple]="false"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </fieldset>
+    <fieldset>
+      <legend>
         <h5 class="section-title">Critères de délimitation de la zone humide</h5>
       </legend>
       <div class="form-row">

--- a/frontend/app/zh-forms/tabs/tab2/zh-form-tab2.component.ts
+++ b/frontend/app/zh-forms/tabs/tab2/zh-form-tab2.component.ts
@@ -1,7 +1,8 @@
 import { Component, EventEmitter, Input, OnInit, AfterViewInit, Output } from '@angular/core';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { ToastrService } from 'ngx-toastr';
-import { Subscription } from 'rxjs';
+import { Subscription, of, Observable } from 'rxjs';
+import { debounceTime, distinctUntilChanged, switchMap, catchError, map } from 'rxjs/operators';
 import { ErrorTranslatorService } from '../../../services/error-translator.service';
 import { TabsService } from '../../../services/tabs.service';
 import { ZhDataService } from '../../../services/zh-data.service';
@@ -24,6 +25,12 @@ export class ZhFormTab2Component implements OnInit, AfterViewInit {
   public critDelimFct: any;
   public submitted: boolean;
   public posted: boolean;
+  public listRefGeoSaisie: {
+    name: string;
+  }[] = [];
+  public listEchelleSaisie: {
+    name: string;
+  }[] = [];
 
   constructor(
     private fb: FormBuilder,
@@ -66,12 +73,15 @@ export class ZhFormTab2Component implements OnInit, AfterViewInit {
             selectedCritDelimFs.push(critere);
           }
         });
+
         this.formTab2.patchValue({
           critere_delim: selectedCritDelim,
           id_zh: this.currentZh.properties.id_zh,
           remark_lim: this.currentZh.properties.remark_lim,
           critere_delim_fs: selectedCritDelimFs,
           remark_lim_fs: this.currentZh.properties.remark_lim_fs,
+          echelleSaisie: { name: this.currentZh.properties.input_scale },
+          refGeoSaisie: { name: this.currentZh.properties.input_ref_geo },
         });
         this.$_fromChangeSub = this.formTab2.valueChanges.subscribe(() => {
           this.canChangeTab.emit(false);
@@ -85,6 +95,8 @@ export class ZhFormTab2Component implements OnInit, AfterViewInit {
       critere_delim: [null, Validators.required],
       id_zh: [{ value: null, disabled: true }, Validators.required],
       remark_lim: null,
+      echelleSaisie: null,
+      refGeoSaisie: null,
       critere_delim_fs: null,
       remark_lim_fs: null,
     });
@@ -102,6 +114,8 @@ export class ZhFormTab2Component implements OnInit, AfterViewInit {
       id_zh: Number(this.currentZh.properties.id_zh),
       remark_lim_fs: formValues.remark_lim_fs,
       remark_lim: formValues.remark_lim,
+      input_scale: Number(this.formTab2.value.echelleSaisie.name),
+      input_ref_geo: this.formTab2.value.refGeoSaisie.name,
       critere_delim_fs: [],
     };
 
@@ -137,6 +151,24 @@ export class ZhFormTab2Component implements OnInit, AfterViewInit {
       );
     }
   }
+
+  allListEchelleSaisie = () => {
+    this._dataService.getEchelleSaisie().subscribe((res) => {
+      this.listEchelleSaisie = [];
+      res.map((elem) => {
+        this.listEchelleSaisie.push({ name: elem });
+      });
+    });
+  };
+
+  allListRefGeoSaisie = () => {
+    this._dataService.getRefGeoSaisie().subscribe((res) => {
+      this.listRefGeoSaisie = [];
+      res.map((elem) => {
+        this.listRefGeoSaisie.push({ name: elem });
+      });
+    });
+  };
 
   ngOnDestroy() {
     if (this.$_currentZhSub) this.$_currentZhSub.unsubscribe();

--- a/frontend/app/zh-map-list/zh-map-list.component.ts
+++ b/frontend/app/zh-map-list/zh-map-list.component.ts
@@ -182,6 +182,13 @@ export class ZhMapListComponent implements OnInit, OnDestroy, AfterViewInit {
     return sdage.mnemonique;
   }
 
+  displayEchelleSaisie(element): string {
+    if (!element) {
+      return 'Non renseignée';
+    }
+    return `1/${element}ème`;
+  }
+
   displayOrganism(authors): string {
     return authors.organisme.nom_organisme;
   }
@@ -196,6 +203,9 @@ export class ZhMapListComponent implements OnInit, OnDestroy, AfterViewInit {
     // format Date
     feature['properties']['create_date'] = this.displayDate(feature['properties']['create_date']);
     feature['properties']['update_date'] = this.displayDate(feature['properties']['update_date']);
+    feature['properties']['input_scale'] = this.displayEchelleSaisie(
+      feature['properties']['input_scale']
+    );
 
     feature['properties']['sdage'] = this.displaySdageName(feature['properties']['id_sdage']);
 


### PR DESCRIPTION
Cette PR ajoute 3 champs dans la base 't_zh'.

De plus elle ajoute une colonne dans la table bib_organisme afin de pourvoir avoir une auto complétion dans l'interface sur 'maitre_ouvrage' .

Elle rajoute aussi des éléments dans ref_nommenclature et bib_nommenclature_type.

Pour finir les champs sont modifiable, consultable, disponible dans les pdfs et 'maitre_ouvrage', 'echelle_saisie' sont disponible dans le pbf.

https://github.com/PnX-SI/gn_module_ZH/issues/52


En lien avec : https://github.com/PnX-SI/GeoNature-ZH-atlas/pull/10
