### PR TITLE
fix load pdf_last_page_img

### DIFF
--- a/backend/gn_module_zh/templates/fiche_template_pdf.html
+++ b/backend/gn_module_zh/templates/fiche_template_pdf.html
@@ -29,9 +29,11 @@
       {% include 'evaluation.html' %}
     </div>
     </br>
+    {% if data['config']['pdf_last_page_img'] %}
     <div>
       <img class="banner" src="{{ url_for('pr_zh.static', filename=data['config']['pdf_last_page_img']) }}">
     </div>
+    {% endif %}
   </body>
 <style>
   /* Puts style here since I cannot make blueprint static files work...*/


### PR DESCRIPTION
https://github.com/PnX-SI/gn_module_ZH/issues/132
Ajout d'une clause `if ... endif` au chargement de l'image de bas de page dans le ficher `fiche_template_pdf.html`