### PR TITLE
Feat: pdf download from blob to pdf

### DIFF
--- a/backend/gn_module_zh/blueprint.py
+++ b/backend/gn_module_zh/blueprint.py
@@ -19,6 +19,7 @@ from flask import (
 from flask.helpers import send_file
 from geojson import FeatureCollection
 from werkzeug.exceptions import Forbidden, BadRequest, NotFound
+from werkzeug.utils import secure_filename
 
 from geonature.core.gn_commons.models import TMedias
 
@@ -946,11 +947,12 @@ def download(id_zh: int):
     author = f"{author_role.prenom_role} {author_role.nom_role.upper()}"
     last_date = zh.update_date
     media = get_last_pdf_export(id_zh=id_zh, last_date=last_date)
+    filename = secure_filename(f"{zh.code}_{dt.now().strftime('%d-%m-%Y')}_fiche.pdf")
+
     if media is None:
         dataset = get_complete_card(id_zh)
         dataset["config"] = blueprint.config
-        filename = f'{id_zh}_fiche_{dt.now().strftime("%Y-%m-%d")}.pdf'
-        stored_filename = f"zh_{uuid.uuid4()}.pdf"
+        stored_filename = secure_filename(f"zh_{uuid.uuid4()}.pdf")
         media_path = Path(BACKEND_DIR, config["MEDIA_FOLDER"], "pdf", stored_filename)
         pdf_file = gen_pdf(id_zh=id_zh, dataset=dataset, filename=media_path)
         post_file_info(
@@ -962,9 +964,13 @@ def download(id_zh: int):
             media_path=str(media_path),
         )
 
-        return send_file(pdf_file, as_attachment=True)
+        response = send_file(pdf_file, mimetype="application/pdf")
+        response.headers["Content-Disposition"] = f'inline; filename="{filename}"'
+        return response
     else:
-        return send_file(get_file_path(media.id_media), as_attachment=True)
+        response = send_file(get_file_path(media.id_media), mimetype="application/pdf")
+        response.headers["Content-Disposition"] = f'inline; filename="{filename}"'
+        return response
 
 
 @blueprint.route("/departments", methods=["GET"])

--- a/frontend/app/services/zh-data.service.ts
+++ b/frontend/app/services/zh-data.service.ts
@@ -126,9 +126,8 @@ export class ZhDataService {
   }
 
   getPdf(zhId: number) {
-    return this._api.get(`${this.config.API_ENDPOINT}/zones_humides/export_pdf/${zhId}`, {
-      responseType: 'blob',
-    });
+    const baseUrl = `${this.config.API_ENDPOINT}/zones_humides/export_pdf/${zhId}`;
+    return baseUrl;
   }
 
   getDepartments() {

--- a/frontend/app/zh-details/header/header.component.ts
+++ b/frontend/app/zh-details/header/header.component.ts
@@ -60,30 +60,9 @@ export class HeaderComponent {
 
   onDownloadPdf() {
     this.loadingPdf = true;
-    this._zhService.getPdf(this.zhId).subscribe(
-      (result) => {
-        this.loadingPdf = false;
-        const rawDate: string = new Date().toLocaleDateString();
-        const date: string = rawDate.replace(/\//g, '-');
-        const filename: string = `${this.zhCode}_${date}_fiche.pdf`;
-        // Not possible to use saveas since it does not open it in a
-        // new tab => create a <a> then click on it...
-        const blob = new Blob([result], { type: 'application/type' });
-        const url = window.URL.createObjectURL(blob);
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = filename;
-        link.target = '_blank';
-        link.click();
-      },
-      (error) => {
-        this.loadingPdf = false;
-        const frontMsg: string =
-          'Erreur de téléchargement du PDF ' + this._error.getFrontError(error.error.message);
-        this._commonService.translateToaster('error', frontMsg);
-      },
-      () => (this.loadingPdf = false)
-    );
+    const pdfUrl = this._zhService.getPdf(this.zhId);
+    window.open(pdfUrl, '_blank', 'noopener');
+    setTimeout(() => (this.loadingPdf = false), 300);
   }
 
   resetTabService() {


### PR DESCRIPTION
Evolution de la génération de PDF. 
Le fichier n'est plus tranmis via un blob, mais un pdf officiel (mimetype="application/pdf")
Plus propre, pas sauvé par défault. 

Le nom du fichier est maintenant celui généré par le backend, pa de duplication de cette génération. un "securefilename" a été rajouté. 