### PR TITLE
fix: test exclude debian 13 and geonature 2.16.0 from ci tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         geonature_ref: [
-          "2.16.0",
+          "2.17.0",
           "master",
           "develop"
         ] # Mettre version compatible


### PR DESCRIPTION
Effectivement impossible en l'état de surcharger les versions de debian a utiliser pour les tests donc j'ai enlevé la version 2.16.0 des tests