### PR TITLE
Param Var CRONTAB

### DIFF
--- a/backend/gn_module_zh/conf_schema_toml.py
+++ b/backend/gn_module_zh/conf_schema_toml.py
@@ -119,6 +119,12 @@ flora_view_name = {"schema_name": "pr_zh", "table_name": "vm_flora", "category":
 # Fréquence de mise à jour des vm de taxons
 TAXON_VM_CRONTAB = "0 0,12 * * *"
 
+# Fréquence de mise à jour de la vm des règles de hiérarchisation
+RB_RULES_VM_CRONTAB = "0 * * * *"
+
+# Fréquence de mise à jour des notes
+UPDATE_NOTES_CRONTAB = "5 * * * *"
+
 # Name of the source of species data (tab5)
 species_source_name = "GeoNature"
 
@@ -204,6 +210,8 @@ class GnModuleSchemaConf(Schema):
     pdf_last_page_img = fields.String(load_default=pdf_last_page_img)
     pdf_title = fields.String(load_default=pdf_title)
     TAXON_VM_CRONTAB = fields.String(load_default=TAXON_VM_CRONTAB)
+    RB_RULES_VM_CRONTAB = fields.String(load_default=RB_RULES_VM_CRONTAB)
+    UPDATE_NOTES_CRONTAB = fields.String(load_default=UPDATE_NOTES_CRONTAB)
     pdf_sections_included = fields.Nested(
         PdfSectionsIncludedConfig, load_default=PdfSectionsIncludedConfig().load({})
     )

--- a/backend/gn_module_zh/tasks.py
+++ b/backend/gn_module_zh/tasks.py
@@ -32,7 +32,8 @@ def setup_periodic_tasks(sender, **kwargs):
 
 @celery_app.on_after_finalize.connect
 def setup_periodic_tasks_for_vm_rb_rules(sender, **kwargs):
-    minute, hour, day_of_month, month_of_year, day_of_week = "* * * * *".split(" ")
+    ct = config["ZONES_HUMIDES"]["RB_RULES_VM_CRONTAB"]
+    minute, hour, day_of_month, month_of_year, day_of_week = ct.split(" ")
     sender.add_periodic_task(
         crontab(
             minute=minute,
@@ -48,7 +49,8 @@ def setup_periodic_tasks_for_vm_rb_rules(sender, **kwargs):
 
 @celery_app.on_after_finalize.connect
 def setup_periodic_tasks_update_notes(sender, **kwargs):
-    minute, hour, day_of_month, month_of_year, day_of_week = "* * * * *".split(" ")
+    ct = config["ZONES_HUMIDES"]["UPDATE_NOTES_CRONTAB"]
+    minute, hour, day_of_month, month_of_year, day_of_week = ct.split(" ")
     sender.add_periodic_task(
         crontab(
             minute=minute,

--- a/doc/admin.md
+++ b/doc/admin.md
@@ -66,7 +66,12 @@ Les vues matérisalisées sont mises à jour automatiquement à fréquence défi
   
      TAXON_VM_CRONTAB ="0 0,12 * * *"
 
-Ce paramètre est composé de cinq valeurs, chacune séparée par un espace: minute, heure, jour du mois, mois de l'année, journée de la semaine. Dans l'exemple ci-dessus, il est indiqué que la mise à jour sera effectuée toutes les 12 heures. Pour plus d'informations, vous pouvez consulter la documentation de Celery à ce sujet : https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html#crontab-schedules.
+La fréquence de rafraîchissement de la vue matérialisée des règles de hiérarchisation et celle de mise à jour des notes sont également configurables. Par défaut, la vue des règles est rafraîchie toutes les heures, puis les notes sont recalculées cinq minutes plus tard afin d'utiliser les nouveaux dénominateurs :
+
+     RB_RULES_VM_CRONTAB = "0 * * * *"
+     UPDATE_NOTES_CRONTAB = "5 * * * *"
+
+Chaque paramètre est composé de cinq valeurs, séparées par des espaces : minute, heure, jour du mois, mois de l'année et jour de la semaine. Pour plus d'informations, vous pouvez consulter la documentation de Celery à ce sujet : https://docs.celeryq.dev/en/stable/userguide/periodic-tasks.html#crontab-schedules.
 
 **Note** : Si vous ne voulez pas définir un des paramètres de périodicité, utilisez un astérisque (``*``).
 

--- a/zones_humides_config.toml.example
+++ b/zones_humides_config.toml.example
@@ -89,6 +89,12 @@ flora_view_name = { schema_name = "pr_zh", table_name = "vm_flora", category = "
 # Fréquence de mise à jour des vm de taxons
 TAXON_VM_CRONTAB = "0 0,12 * * *"
 
+# Fréquence de mise à jour de la vm des règles de hiérarchisation
+RB_RULES_VM_CRONTAB = "0 * * * *"
+
+# Fréquence de mise à jour des notes, après le rafraîchissement des règles
+UPDATE_NOTES_CRONTAB = "5 * * * *"
+
 # Nom de la source de données pour la liste des taxons (tab5)
 species_source_name = "GeoNature"
 


### PR DESCRIPTION
Ajout de 2 var permettant de définir la fréquence de refresh des vm. 
Actuellement toutes les minutes, soit 2880 fois par jour pour les 2 tâches, c'est beaucoup pour l'usage que l'on a et ça pollue les logs celery.
Passage a toutes les heures, ce qui me semble raisonnable comme attente pour l'user.